### PR TITLE
Update the CFT and guide to tell you to use the private IP.

### DIFF
--- a/docs/_static/f5-ci-beta.cloudformation.json
+++ b/docs/_static/f5-ci-beta.cloudformation.json
@@ -1448,19 +1448,6 @@
           "NetworkInterfaceId" : { "Ref" : "SplunkReadyAdminXface" }
         }
       },
-      "SplunkReadyPrivateXface" : {
-        "Type" : "AWS::EC2::NetworkInterface",
-        "Properties": {
-          "SubnetId" : {
-            "Ref" : "InternalSubnet"
-          },
-          "GroupSet" : [
-            {
-              "Ref" : "SlaveSecurityGroup"
-            }
-          ]
-        }
-      },
       "SplunkReadyInstance" : {
         "Type": "AWS::EC2::Instance",
         "DependsOn": "GatewayToInternet",
@@ -1477,10 +1464,6 @@
             {
               "DeviceIndex" : "0",
               "NetworkInterfaceId" : { "Ref" : "SplunkReadyAdminXface" }
-            },
-            {
-              "DeviceIndex" : "1",
-              "NetworkInterfaceId" : { "Ref" : "SplunkReadyPrivateXface" }
             }
           ],
           "Tags" : [
@@ -2191,6 +2174,13 @@
             "ssh ec2-user@",
             { "Ref": "SplunkReadyAdminEIP" }
           ] ]
+        }
+      },
+      "SplunkReadyPrivateIP" : {
+        "Description": "Private IP that data sources should use to send to splunk",
+        "Value": {
+          "Fn::GetAtt" : [ "SplunkReadyAdminXface",
+                           "PrimaryPrivateIpAddress" ]
         }
       }
    },

--- a/usage-marathon-poc.rst
+++ b/usage-marathon-poc.rst
@@ -102,6 +102,7 @@ In this section, we guide you through the installation of a new Mesos and Marath
         - **BIGIPAdminPassword**: the password for the 'admin' user on the BIG-IP.
         - **MarathonUI**: the URL for the Marathon UI.
         - **SplunkReadySSH**: the ssh command to log into an instance ready for Splunk installation.
+        - **SplunkReadyPrivateIP**: if you install Splunk on the Splunk-ready instance, substitute this for [SPLUNK_IP].
 
 .. note::
 
@@ -156,7 +157,7 @@ You'll need to install Splunk somewhere that data from the web applications will
 
 #. Configure your firewall to allow port 8088 to be open to Splunk.
 
-    .. note:: If you are using the provided cloud stack, this has already been done.
+    .. note:: If you are using the provided cloud stack, this has already been done. The BIG-IP and Mesos nodes can send data to splunk at the **SplunkReadyPrivateIP** above.
 
 
 Install the F5 Splunk Apps


### PR DESCRIPTION
If you use the public IP, it only works if you didn't specify a CIDR for
filtering admin access (or you go and add rules).  If you use the
private IP, it will work.

It's easiest to just use the admin private IP because it's routable from
the internal net (mesos nodes) and also BIG-IP's admin interface.  So
remove the SplunkReadyPrivateXface entirely to keep things simple.

Also add an output "SplunkReadyPrivateIP" to the CFT so that users don't
have to go digging through EC2 to find the IP.
