### PR TITLE
Specify that you should create the Analytics app service in Common

### DIFF
--- a/usage-marathon-poc.rst
+++ b/usage-marathon-poc.rst
@@ -493,7 +493,7 @@ Use an F5 iApps® template file to enable stats collection on your BIG-IP and se
 
 #. Upload the iApp template (:file:`f5.analytics.tmpl`).
 
-#. Select :menuselection:`IApps/Application Services --> Create`.
+#. Ensure you are in the Common partition (top-right), then select :menuselection:`IApps/Application Services --> Create`.
 
 #. Choose the :file:`f5.analytics` template.
 


### PR DESCRIPTION
Problem: 2 users (Kevin and myself) accidentally created the iApp in the
mesos partition while dry-running the instructions.  This fights the
f5-marathon-lb and can lead to errors.

Solution: Specify that you should create it in the Common partition.
