### PR TITLE
Update f5-marathon-lb versions to v0.1.2 to fix f5-marathon-lb #62

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -78,12 +78,12 @@ author = u'F5 Networks'
 # The short X.Y version.
 version = 'v0.1'
 # The full version, including alpha/beta/rc tags.
-#release = 'v0.1.1'
+#release = 'v0.1.2'
 
 # Individual project versions
 
 rst_epilog = """
-.. |f5mlb_version| replace:: v0.1.1
+.. |f5mlb_version| replace:: v0.1.2
 .. |lwp_version| replace:: v0.1.0
 .. |lwpc_version| replace:: v0.1.1
 """

--- a/docs/includes/topic_f5-mesos-csi-install.rst
+++ b/docs/includes/topic_f5-mesos-csi-install.rst
@@ -33,7 +33,7 @@ How to Deploy f5-marathon-lb in Marathon
           "docker": {
             "network": "BRIDGE",
             "parameters": [],
-            "image": "<your_registry>/f5-marathon-lb:v0.1.1",
+            "image": "<your_registry>/f5-marathon-lb:v0.1.2",
           },
           "type": "DOCKER",
           "volumes": []
@@ -41,8 +41,8 @@ How to Deploy f5-marathon-lb in Marathon
       }
 
     .. important::
-    
-        * All options enclosed with "<>" -- for example, "<your_registry>/f5-marathon-lb:v0.1.1" -- must be replaced with the appropriate information for your environment.
+
+        * All options enclosed with "<>" -- for example, "<your_registry>/f5-marathon-lb:v0.1.2" -- must be replaced with the appropriate information for your environment.
         * DC/OS users: Use http://mesos.master:8080 as the value for <marathon_url> in the example above.
 
 #. Next, create the application in Marathon from the command line with the following command referencing the file created earlier:
@@ -60,17 +60,17 @@ How to Save the Docker Image Locally (Optional)
 #. Pull the f5-marathon-lb image from Docker Hub:
 
     .. note::
-        
+
          See :ref:`Docker Authorization` to enable access to the private beta repository.
 
     .. code-block:: bash
 
-      docker pull f5networks/f5-ci-beta:f5-marathon-lb-v0.1.1
+      docker pull f5networks/f5-ci-beta:f5-marathon-lb-v0.1.2
 
 #. Push the image to your own Docker repository:
 
     .. code-block:: bash
 
         # Tag and push the downloaded image to your private Docker registry.
-        docker tag f5networks/f5-ci-beta:f5-marathon-lb-v0.1.1 <your_registry>/f5-marathon-lb:v0.1.1
-        docker push <your_registry>/f5-marathon-lb:v0.1.1
+        docker tag f5networks/f5-ci-beta:f5-marathon-lb-v0.1.2 <your_registry>/f5-marathon-lb:v0.1.2
+        docker push <your_registry>/f5-marathon-lb:v0.1.2

--- a/usage-marathon-poc.rst
+++ b/usage-marathon-poc.rst
@@ -228,7 +228,7 @@ The **f5-marathon-lb** component of the F5 Container Service Integration (CSI) i
                 {}
               ],
               "privileged": false,
-              "image": "f5networks/f5-ci-beta:f5-marathon-lb-v0.1.1",
+              "image": "f5networks/f5-ci-beta:f5-marathon-lb-v0.1.2",
               "network": "BRIDGE",
               "forcePullImage": true
             },
@@ -298,7 +298,7 @@ The **f5-marathon-lb** component of the F5 Container Service Integration (CSI) i
                 "type": "DOCKER",
                 "volumes": [],
                 "docker": {
-                    "image": "f5networks/f5-ci-beta:f5-marathon-lb-v0.1.1",
+                    "image": "f5networks/f5-ci-beta:f5-marathon-lb-v0.1.2",
                     "network": "BRIDGE",
                     "portMappings": [{
                         "containerPort": 0,


### PR DESCRIPTION
Fixes #49 Beta docs should use f5-marathon-lb v0.1.2 to incorporate a bugfix
### Describe the problem / feature to which this change applies

Problem: Beta refers to f5-marathon-lb v0.1.1 but it should now refer to v0.1.2 so that users get a fix for f5-marathon-lb issue 62 (Node creation may fail if mesos hostname is not an IP address)
### Describe the change(s) made and why

Analysis: Replace all references to f5-marathon-lb v0.1.1 with v0.1.2.  Do not update lightweight-proxy or lwp-controller; those remain the same.
