### PR TITLE
Travis-ci deployment to AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,28 @@ script:
 - ./scripts/docker-docs.sh ./scripts/test-docs.sh
 deploy:
   - provider: s3
-    access_key_id: $S3_ACCESS_ID
-    secret_access_key: $S3_ACCESS_KEY
-    bucket: $S3_BUCKET_NAME
+    access_key_id:
+      secure: "$S3_ACCESS_ID_SECURE"
+    secret_access_key:
+      secure: "$S3_ACCESS_KEY_SECURE"
+    bucket: "$S3_BUCKET_NAME"
     local-dir: docs/_build/html
     upload-dir: f5-container-docs/$TRAVIS_TAG
-    #acl: ''
     skip-cleanup: true
     region: "us-west-2"
     on:
       tags: true
   - provider: s3
-    access_key_id: $S3_ACCESS_ID
-    secret_access_key: $S3_ACCESS_KEY
-    bucket: $S3_BUCKET_NAME
+    access_key_id:
+      secure: "$S3_ACCESS_ID_SECURE"
+    secret_access_key:
+      secure: "$S3_ACCESS_KEY_SECURE"
+    bucket: "$S3_BUCKET_NAME"
     local-dir: docs/_build/html
     upload-dir: f5-container-docs/$TRAVIS_BRANCH
-    #acl: ''
     skip-cleanup: true
     region: "us-west-2"
     on:
       all_branches: true
       condition: '"$TRAVIS_PULL_REQUEST" == "false"'
+


### PR DESCRIPTION
## Headline or summary  of the issue you are fixing
@bmarshall13 -- new PR, from the correct branch this time.

### Fixes #80 

### Describe the problem/feature to which this change applies
Problem: We need to securely deploy documentation to AWS s3 on successful builds when a) a release tag is made and/or b) a commit is made directly to any branch (i.e., is not a pull request). 

As currently configured, no deployments will occur on branches that aren't master, even if tagged. We may need to revisit how to set up the deployments so the second option will deploy even (or especially) if the first doesn't.

### Describe the change(s) made and why
Analysis: I secured the environment variables as discussed and linted the travis.yaml file.  


