### PR TITLE
Fixes: #116 - Add Splunk 'How To'

### DIFF
--- a/docs/drafts/deploy-f5-analytics-iapp.rst
+++ b/docs/drafts/deploy-f5-analytics-iapp.rst
@@ -1,0 +1,18 @@
+Deploy the F5 Analytics iApp in Kubernetes
+``````````````````````````````````````````
+
+Use the |kctlr-long| to :ref:`deploy the iApp in Kubernetes <kctlr-deploy-iapps>`.
+
+.. table:: F5 Analytics iApp Resource values
+
+    ========================    ==========================
+    Key                         Value
+    ========================    ==========================
+    tbd                         tbd
+    ========================    ==========================
+
+Deploy the F5 Analytics iApp in Marathon
+````````````````````````````````````````
+
+Use the |mctlr-long| to :ref:`deploy the iApp in Marathon <mctlr-deploy-iapps>`.
+

--- a/docs/drafts/how-to-create-iapp-variables.rst
+++ b/docs/drafts/how-to-create-iapp-variables.rst
@@ -7,305 +7,316 @@ The |kctlr-long| and |mctlr-long| both support deployment of iApps, which gives 
 
 .. important::
 
-    The instructions provided here apply to all supported orchestration environments. In the examples, we reference Marathon and the |mctlr-long|.
+    The instructions provided here for determining which iApp variables to create apply to all supported orchestration environments. In the examples, we reference Marathon and the |mctlr-long|.
 
 At a high level, the way it works is:
 
-1) You define a new Application in Marathon, with F5 :ref:`Application labels <app-labels>` defined.
-2) The |mctlr| notices the new labels and configures a new iApp on the BIG-IP. Referencing an iApp Template that already exists on the BIG-IP.
-3) The BIG-IP invokes the iApp template to handle the newly-defined iApp. The iApp template can create a virtual server, pool members, and so on. 
+1) You define a new Application in Marathon, with the :ref:`marathon-bigip-ctlr iApp Application labels for iApp mode </products/connectors/marathon-bigip-ctlr/latest/index.html#application-labels-for-iapp-mode>` defined.
+2) The |mctlr-long| notices the new labels and configures a new iApp on the BIG-IP.
+3) The iApp template is invoked to handle the new iApp the |mctlr| defined. The iApp template can create a virtual server, pool members, and so on. 
 
-First, you need to determine what fields in the iApp template need correspondin ``iappVariables``.
+First, you need to determine what fields in the iApp template need corresponding ``iappVariables``.
 
-#. We recommend that you `deploy the iApp <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-iapps-developer-11-4-0/2.html#unique_1831084015>`_ using the BIG-IP configuration utility.
+#. `Deploy an iApp <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-iapps-developer-11-4-0/2.html#unique_1831084015>`_ using the BIG-IP configuration utility.
 
 #. Make a REST call to the BIG-IP to determine the configurations applied.
 
-It can do anything an iApp can do, which gives it access to essentially all the advanced features on BIG-IP.
+
+.. rubric:: For example:
  
-Here's the JSON for an example application configured in Marathon (via ``curl -v -H "Accept: application/json" http://10.190.25.245:8080/v2/apps/test-svc | json_pp``).  It's long; I bold-faced the interesting parts:
+Here's the JSON for an example application configured in Marathon
+
+.. code-block:: json
+    :linenos:
+    :emphasize-lines:
+         
+        {
+           "app" : {
+              "instances" : 2,
+              "acceptedResourceRoles" : null,
+              "tasksStaged" : 0,
+              "env" : {},
+              "container" : {
+                 "type" : "DOCKER",
+                 "docker" : {
+                    "privileged" : false,
+                    "forcePullImage" : true,
+                    "portMappings" : [
+                       {
+                          "containerPort" : 80,
+                          "hostPort" : 0,
+                          "servicePort" : 10001,
+                          "protocol" : "tcp"
+                       }
+                    ],
+                    "network" : "BRIDGE",
+                    "image" : "docker-registry.pdbld.f5net.com/systest-common/test-nginx",
+                    "parameters" : []
+                 },
+                 "volumes" : []
+              },
+              "maxLaunchDelaySeconds" : 3600,
+              "executor" : "",
+              "tasksRunning" : 2,
+              "healthChecks" : [
+                 {
+                    "gracePeriodSeconds" : 10,
+                    "maxConsecutiveFailures" : 3,
+                    "protocol" : "TCP",
+                    "timeoutSeconds" : 5,
+                    "ignoreHttp1xx" : false,
+                    "portIndex" : 0,
+                    "intervalSeconds" : 5
+                 }
+              ],
+              "backoffSeconds" : 1,
+              "tasksHealthy" : 2,
+              "disk" : 0,
+              "requirePorts" : false,
+              "mem" : 32,
+              "ports" : [
+                 10001
+              ],
+              "uris" : [],
+              "dependencies" : [],
+              "cpus" : 0.1,
+              "user" : null,
+              "constraints" : [],
+              "id" : "/test-svc",
+              "versionInfo" : {
+                 "lastScalingAt" : "2017-02-03T23:06:03.940Z",
+                 "lastConfigChangeAt" : "2017-02-03T23:05:38.429Z"
+              },
+              "deployments" : [],
+              "tasks" : [
+                 {
+                    "appId" : "/test-svc",
+                    "startedAt" : "2017-02-03T23:05:55.329Z",
+                    "id" : "test-svc.470699a1-ea65-11e6-b367-fa163ef52e22",
+                    "healthCheckResults" : [
+                       {
+                          "consecutiveFailures" : 0,
+                          "taskId" : "test-svc.470699a1-ea65-11e6-b367-fa163ef52e22",
+                          "alive" : true,
+                          "firstSuccess" : "2017-02-03T23:05:58.639Z",
+                          "lastFailure" : null,
+                          "lastSuccess" : "2017-02-03T23:20:15.793Z"
+                       }
+                    ],
+                    "ipAddresses" : [],
+                    "host" : "172.16.1.21",
+                    "stagedAt" : "2017-02-03T23:05:38.575Z",
+                    "ports" : [
+                       13122
+                    ],
+                    "slaveId" : "4b371649-4dd7-43bd-bb8c-516f66d34f40-S0",
+                    "version" : "2017-02-03T23:05:38.429Z"
+                 },
+                 {
+                    "host" : "172.16.1.21",
+                    "healthCheckResults" : [
+                       {
+                          "consecutiveFailures" : 0,
+                          "firstSuccess" : "2017-02-03T23:06:29.144Z",
+                          "lastFailure" : null,
+                          "lastSuccess" : "2017-02-03T23:20:16.154Z",
+                          "alive" : true,
+                          "taskId" : "test-svc.56399762-ea65-11e6-b367-fa163ef52e22"
+                       }
+                    ],
+                    "ipAddresses" : [],
+                    "stagedAt" : "2017-02-03T23:06:04.060Z",
+                    "id" : "test-svc.56399762-ea65-11e6-b367-fa163ef52e22",
+                    "startedAt" : "2017-02-03T23:06:25.485Z",
+                    "appId" : "/test-svc",
+                    "version" : "2017-02-03T23:06:03.940Z",
+                    "ports" : [
+                       16324
+                    ],
+                    "slaveId" : "4b371649-4dd7-43bd-bb8c-516f66d34f40-S0"
+                 }
+              ],
+              "args" : null,
+              "cmd" : null,
+              "tasksUnhealthy" : 0,
+              "storeUrls" : [],
+              "version" : "2017-02-03T23:06:03.940Z",
+              "labels" : {
+                 "F5_0_IAPP_VARIABLE_pool__addr" : "172.16.3.2",
+                 "F5_0_IAPP_VARIABLE_monitor__monitor" : "/#create_new#",
+                 "F5_0_IAPP_TEMPLATE" : "/Common/f5.http",
+                 "F5_0_IAPP_OPTION_description" : "This is a test iApp",
+                 "F5_0_IAPP_VARIABLE_net__server_mode" : "lan",
+                 "F5_0_IAPP_VARIABLE_pool__mask" : "255.255.255.255",
+                 "F5_0_IAPP_VARIABLE_client__standard_caching_with_wa" : "/#create_new#",
+                 "F5_0_IAPP_VARIABLE_net__vlan_mode" : "all",
+                 "F5_0_IAPP_VARIABLE_pool__lb_method" : "round-robin",
+                 "F5_0_IAPP_VARIABLE_net__snat_type" : "automap",
+                 "F5_0_IAPP_VARIABLE_client__tcp_wan_opt" : "/#create_new#",
+                 "F5_0_IAPP_VARIABLE_pool__persist" : "/#do_not_use#",
+                 "F5_0_IAPP_VARIABLE_server__tcp_lan_opt" : "/#create_new#",
+                 "F5_0_IAPP_VARIABLE_server__ntlm" : "/#do_not_use#",
+                 "F5_0_IAPP_VARIABLE_monitor__uri" : "/",
+                 "F5_0_IAPP_VARIABLE_server__oneconnect" : "/#create_new#",
+                 "F5_0_IAPP_VARIABLE_monitor__response" : "none",
+                 "F5_0_IAPP_VARIABLE_net__client_mode" : "wan",
+                 "F5_0_IAPP_VARIABLE_ssl_encryption_questions__advanced" : "yes",
+                 "F5_0_IAPP_VARIABLE_pool__port" : "8080",
+                 "F5_0_IAPP_VARIABLE_pool__pool_to_use" : "/#create_new#",
+                 "F5_0_IAPP_VARIABLE_pool__http" : "/#create_new#",
+                 "F5_0_IAPP_POOL_MEMBER_TABLE_NAME" : "pool__members",
+                 "F5_0_IAPP_VARIABLE_monitor__frequency" : "30",
+                 "F5_PARTITION" : "test",
+                 "F5_0_IAPP_VARIABLE_client__standard_caching_without_wa" : "/#do_not_use#"
+              },
+              "backoffFactor" : 1.15,
+              "fetch" : [],
+              "ipAddress" : null,
+              "upgradeStrategy" : {
+                 "maximumOverCapacity" : 1,
+                 "minimumHealthCapacity" : 1
+              }
+           }
+        }
  
-{
-   "app" : {
-      "instances" : 2,
-      "acceptedResourceRoles" : null,
-      "tasksStaged" : 0,
-      "env" : {},
-      "container" : {
-         "type" : "DOCKER",
-         "docker" : {
-            "privileged" : false,
-            "forcePullImage" : true,
-            "portMappings" : [
-               {
-                  "containerPort" : 80,
-                  "hostPort" : 0,
-                  "servicePort" : 10001,
-                  "protocol" : "tcp"
-               }
-            ],
-            "network" : "BRIDGE",
-            "image" : "docker-registry.pdbld.f5net.com/systest-common/test-nginx",
-            "parameters" : []
-         },
-         "volumes" : []
-      },
-      "maxLaunchDelaySeconds" : 3600,
-      "executor" : "",
-      "tasksRunning" : 2,
-      "healthChecks" : [
-         {
-            "gracePeriodSeconds" : 10,
-            "maxConsecutiveFailures" : 3,
-            "protocol" : "TCP",
-            "timeoutSeconds" : 5,
-            "ignoreHttp1xx" : false,
-            "portIndex" : 0,
-            "intervalSeconds" : 5
-         }
-      ],
-      "backoffSeconds" : 1,
-      "tasksHealthy" : 2,
-      "disk" : 0,
-      "requirePorts" : false,
-      "mem" : 32,
-      "ports" : [
-         10001
-      ],
-      "uris" : [],
-      "dependencies" : [],
-      "cpus" : 0.1,
-      "user" : null,
-      "constraints" : [],
-      "id" : "/test-svc",
-      "versionInfo" : {
-         "lastScalingAt" : "2017-02-03T23:06:03.940Z",
-         "lastConfigChangeAt" : "2017-02-03T23:05:38.429Z"
-      },
-      "deployments" : [],
-      "tasks" : [
-         {
-            "appId" : "/test-svc",
-            "startedAt" : "2017-02-03T23:05:55.329Z",
-            "id" : "test-svc.470699a1-ea65-11e6-b367-fa163ef52e22",
-            "healthCheckResults" : [
-               {
-                  "consecutiveFailures" : 0,
-                  "taskId" : "test-svc.470699a1-ea65-11e6-b367-fa163ef52e22",
-                  "alive" : true,
-                  "firstSuccess" : "2017-02-03T23:05:58.639Z",
-                  "lastFailure" : null,
-                  "lastSuccess" : "2017-02-03T23:20:15.793Z"
-               }
-            ],
-            "ipAddresses" : [],
-            "host" : "172.16.1.21",
-            "stagedAt" : "2017-02-03T23:05:38.575Z",
-            "ports" : [
-               13122
-            ],
-            "slaveId" : "4b371649-4dd7-43bd-bb8c-516f66d34f40-S0",
-            "version" : "2017-02-03T23:05:38.429Z"
-         },
-         {
-            "host" : "172.16.1.21",
-            "healthCheckResults" : [
-               {
-                  "consecutiveFailures" : 0,
-                  "firstSuccess" : "2017-02-03T23:06:29.144Z",
-                  "lastFailure" : null,
-                  "lastSuccess" : "2017-02-03T23:20:16.154Z",
-                  "alive" : true,
-                  "taskId" : "test-svc.56399762-ea65-11e6-b367-fa163ef52e22"
-               }
-            ],
-            "ipAddresses" : [],
-            "stagedAt" : "2017-02-03T23:06:04.060Z",
-            "id" : "test-svc.56399762-ea65-11e6-b367-fa163ef52e22",
-            "startedAt" : "2017-02-03T23:06:25.485Z",
-            "appId" : "/test-svc",
-            "version" : "2017-02-03T23:06:03.940Z",
-            "ports" : [
-               16324
-            ],
-            "slaveId" : "4b371649-4dd7-43bd-bb8c-516f66d34f40-S0"
-         }
-      ],
-      "args" : null,
-      "cmd" : null,
-      "tasksUnhealthy" : 0,
-      "storeUrls" : [],
-      "version" : "2017-02-03T23:06:03.940Z",
-      "labels" : {
-         "F5_0_IAPP_VARIABLE_pool__addr" : "172.16.3.2",
-         "F5_0_IAPP_VARIABLE_monitor__monitor" : "/#create_new#",
-         "F5_0_IAPP_TEMPLATE" : "/Common/f5.http",
-         "F5_0_IAPP_OPTION_description" : "This is a test iApp",
-         "F5_0_IAPP_VARIABLE_net__server_mode" : "lan",
-         "F5_0_IAPP_VARIABLE_pool__mask" : "255.255.255.255",
-         "F5_0_IAPP_VARIABLE_client__standard_caching_with_wa" : "/#create_new#",
-         "F5_0_IAPP_VARIABLE_net__vlan_mode" : "all",
-         "F5_0_IAPP_VARIABLE_pool__lb_method" : "round-robin",
-         "F5_0_IAPP_VARIABLE_net__snat_type" : "automap",
-         "F5_0_IAPP_VARIABLE_client__tcp_wan_opt" : "/#create_new#",
-         "F5_0_IAPP_VARIABLE_pool__persist" : "/#do_not_use#",
-         "F5_0_IAPP_VARIABLE_server__tcp_lan_opt" : "/#create_new#",
-         "F5_0_IAPP_VARIABLE_server__ntlm" : "/#do_not_use#",
-         "F5_0_IAPP_VARIABLE_monitor__uri" : "/",
-         "F5_0_IAPP_VARIABLE_server__oneconnect" : "/#create_new#",
-         "F5_0_IAPP_VARIABLE_monitor__response" : "none",
-         "F5_0_IAPP_VARIABLE_net__client_mode" : "wan",
-         "F5_0_IAPP_VARIABLE_ssl_encryption_questions__advanced" : "yes",
-         "F5_0_IAPP_VARIABLE_pool__port" : "8080",
-         "F5_0_IAPP_VARIABLE_pool__pool_to_use" : "/#create_new#",
-         "F5_0_IAPP_VARIABLE_pool__http" : "/#create_new#",
-         "F5_0_IAPP_POOL_MEMBER_TABLE_NAME" : "pool__members",
-         "F5_0_IAPP_VARIABLE_monitor__frequency" : "30",
-         "F5_PARTITION" : "test",
-         "F5_0_IAPP_VARIABLE_client__standard_caching_without_wa" : "/#do_not_use#"
-      },
-      "backoffFactor" : 1.15,
-      "fetch" : [],
-      "ipAddress" : null,
-      "upgradeStrategy" : {
-         "maximumOverCapacity" : 1,
-         "minimumHealthCapacity" : 1
-      }
-   }
-}
- 
-The labels are instructions to f5-marathon-lb about what to do to BIG-IP for this application.  You can also configure an app using the Marathon GUI and specify these labels there.
+
+Container connector iApp configuration parameters
+-------------------------------------------------
                                          
-"F5_PARTITION" : "test":  This is the partition on BIG-IP to create/update/delete the iApp in.  This should be the same partition that you passed to f5-marathon-lb (if it is different, the f5-marathon-lb will assume you actually want some other f5-marathon-lb to handle it, and skip).
+- "F5_PARTITION" : "test":  This is the partition on BIG-IP to create/update/delete the iApp in. This should be the same partition the BIG-IP Container Connector is configured to manage.
  
-"F5_0_IAPP_TEMPLATE" : "/Common/f5.http":  This is the iApp template to invoke.  ("list sys application template" on BIG-IP, or in the GUI under iApps -> Templates.)  These templates can be in any partition that the f5-marathon-lb partition has permissions to refer to; we recommend putting new iApps in /Common in this case so that you follow the rule "Only f5-marathon-lb creates/updates/deletes things in its partition".
+- "F5_0_IAPP_TEMPLATE" : "/Common/f5.http":  This is the iApp template to invoke. These templates can be in any partition that the defined "F5_PARTITION" has permissions to refer to. We recommend putting new iApps in /Common, in keeping with the rule that only the BIG-IP Container Connector should create/update/delete objects in its dedicated partition.
  
-"F5_0_IAPP_POOL_MEMBER_TABLE_NAME" : "pool__members": This is the name of the special iApp table that contains the pool members.  When f5-marathon-lb goes to configure the iApp, it will fill out this table: the pool members are the Marathon tasks for this app.
+- "F5_0_IAPP_POOL_MEMBER_TABLE" :  This is a JSON blob defining the special iApp table that contains the pool members. When the BIG-IP Container Connector goes to configure the iApp, it will fill out this table; the pool members are the Marathon tasks for this App.
  
-"F5_0_IAPP_VARIABLE_*": These are iApp variables - configuration input to the iApp.  These are opaque to f5-marathon-lb.
-  One example - F5_0_IAPP_VARIABLE_pool__addr: "172.16.3.2"
-"F5_0_IAPP_OPTION_*": These are iApp options - configuration input to the iApp.  These are opaque to f5-marathon-lb.
-  One example - F5_0_IAPP_OPTION_description: "This is a test iApp"
- 
-The best way to understand _VARIABLE_ and _OPTION_ is to look at what this configuration produces on the BIG-IP. 
+- "F5_0_IAPP_VARIABLE_*": These iApp variables specify user-provided configuration input required by the iApp. These are opaque to the BIG-IP Container Connectors. For example:
+    The Marathon Application label ``F5_0_IAPP_VARIABLE_pool__addr: "172.16.3.2"`` defines the IP address to assign to the pool created by the iApp.
 
-Notice how it populates F5_0_IAPP_VARIABLE_pool__addr in the "variables" section, and the F5_0_IAPP_OPTION_description in the top-level option "description".
+- "F5_0_IAPP_OPTION_*": These iApp options also specify user-provided configuration input, but they're not fields that are required by the iApp. These are also opaque to the BIG-IP Container Connectors. For example: The Marathon Application Label ``F5_0_IAPP_OPTION_description: "This is a test iApp"`` populates the iApp's "description" field.
  
-root@(bigip)(cfg-sync Standalone)(Active)(/Common)(tmos)# list sys app service /test/test-svc_iapp_10001.app/test-svc_iapp_10001
-sys application service /test/test-svc_iapp_10001.app/test-svc_iapp_10001 {
-    description "This is a test iApp"
-    device-group none
-    inherited-devicegroup true
-    partition test
-    tables {
-        pool__members {
-            column-names { addr port connection_limit }
-            rows {
-                {
-                    row { 172.16.1.21 13122 0 }
-                }
-                {
-                    row { 172.16.1.21 16324 0 }
-                }
-            }
-        }
-    }
-    template f5.http
-    traffic-group traffic-group-local-only
-    variables {
-        client__standard_caching_with_wa {
-            value "/#create_new#"
-        }
-        client__standard_caching_without_wa {
-            value "/#do_not_use#"
-        }
-        client__tcp_wan_opt {
-            value "/#create_new#"
-        }
-        monitor__frequency {
-            value 30
-        }
-        monitor__monitor {
-            value "/#create_new#"
-        }
-        monitor__response {
-            value none
-        }
-        monitor__uri {
-            value /
-        }
-       net__client_mode {
-            value wan
-        }
-        net__server_mode {
-            value lan
-        }
-        net__snat_type {
-            value automap
-        }
-        net__vlan_mode {
-            value all
-        }
-        pool__addr {
-            value 172.16.3.2
-        }
-        pool__http {
-            value "/#create_new#"
-        }
-        pool__lb_method {
-            value round-robin
-        }
-        pool__mask {
-            value 255.255.255.255
-        }
-        pool__persist {
-            value "/#do_not_use#"
-        }
-        pool__pool_to_use {
-            value "/#create_new#"
-        }
-        pool__port {
-            value 8080
-        }
-        server__ntlm {
-            value "/#do_not_use#"
-        }
-        server__oneconnect {
-            value "/#create_new#"
-        }
-        server__tcp_lan_opt {
-            value "/#create_new#"
-        }
-        ssl_encryption_questions__advanced {
-            value yes
-        }
-    }
-}
- 
-Now on the BIG-IP GUI, I can go to iApps -> Application Services, then make sure I am in the "test" partition (top-right), and see the iApp instance and the objects it created:
- 
+The best way to understand ``_VARIABLE_`` and ``_OPTION_`` is to look at what the configuration produces on the BIG-IP. 
 
+Notice that ``F5_0_IAPP_VARIABLE_pool__addr`` is defined in the "variables" section, while ``F5_0_IAPP_OPTION_description`` is defined in the top-level option "description".
  
-In my opinion, the easiest way to identify the \OPTIONS_ and \VARIABLES_ information for an existing iApp is to configure one on the BIG-IP "by hand", then do "list sys app service <foo>" to see what the resulting \OPTIONS_ and \VARIABLES_ are.  You can also actually read the iApp template on the BIG-IP (or write a new one yourself), too.
+.. code-block:: text
+    :linenos:
+    :emphasize-lines: 3, 7-19, 56
+
+    root@(host-172)(cfg-sync Standalone)(Active)(/Common)(tmos)# list sys app service /test/test-svc_iapp_10001.app/test-svc_iapp_10001
+    sys application service /test/test-svc_iapp_10001.app/test-svc_iapp_10001 {
+        description "This is a test iApp"
+        device-group none
+        inherited-devicegroup true
+        partition test
+        tables {
+            pool__members {
+                column-names { addr port connection_limit }
+                rows {
+                    {
+                        row { 172.16.1.21 13122 0 }
+                    }
+                    {
+                        row { 172.16.1.21 16324 0 }
+                    }
+                }
+            }
+        }
+        template f5.http
+        traffic-group traffic-group-local-only
+        variables {
+            client__standard_caching_with_wa {
+                value "/#create_new#"
+            }
+            client__standard_caching_without_wa {
+                value "/#do_not_use#"
+            }
+            client__tcp_wan_opt {
+                value "/#create_new#"
+            }
+            monitor__frequency {
+                value 30
+            }
+            monitor__monitor {
+                value "/#create_new#"
+            }
+            monitor__response {
+                value none
+            }
+            monitor__uri {
+                value /
+            }
+           net__client_mode {
+                value wan
+            }
+            net__server_mode {
+                value lan
+            }
+            net__snat_type {
+                value automap
+            }
+            net__vlan_mode {
+                value all
+            }
+            pool__addr {
+                value 172.16.3.2
+            }
+            pool__http {
+                value "/#create_new#"
+            }
+            pool__lb_method {
+                value round-robin
+            }
+            pool__mask {
+                value 255.255.255.255
+            }
+            pool__persist {
+                value "/#do_not_use#"
+            }
+            pool__pool_to_use {
+                value "/#create_new#"
+            }
+            pool__port {
+                value 8080
+            }
+            server__ntlm {
+                value "/#do_not_use#"
+            }
+            server__oneconnect {
+                value "/#create_new#"
+            }
+            server__tcp_lan_opt {
+                value "/#create_new#"
+            }
+            ssl_encryption_questions__advanced {
+                value yes
+            }
+        }
+    }
  
-Changes to labels or Marathon tasks (containers die or spawn) will reconfigure the iApp.
+Now, on the BIG-IP configuration utility, you can go to iApps -> Application Services and see the iApp instance and the objects it created.
  
-The pool members table the iApp creates resembles the "tmsh list" output for the iApp:
+The easiest way to identify the ``_OPTIONS_`` and ``_VARIABLES_`` information for an existing iApp is to configure the iApp on the BIG-IP "by hand", then do "list sys app service <foo>" to see what the resulting ``_OPTIONS_`` and ``_VARIABLES_`` are. 
+
+You can also read the iApp template on the BIG-IP (or write a new one yourself) to determine the fields the user is expected/required to populate.
+ 
+The iApp is reconfigured whenever the labels or the Marathon tasks/Kubernetes Pods change (containers die or are spawned).
+ 
+The pool members table is filled out according to the JSON blob defined for the Container Connector. It looks a lot like what you see in the ``tmsh list`` output.
+
+::
    
     tables {
-        pool__members {
-            column-names { addr port connection_limit }
-            rows {
-                {
-                    row { 172.16.1.21 13122 0 }
-                }
-                {
-                    row { 172.16.1.21 16324 0 }
-                }
-            }
-        }
-    }
+            pool__members {
+                column-names { addr port connection_limit }
+                rows {
+                    {
+                        row { 172.16.1.21 13122 0 }
+                    }
+                    {
+                        row { 172.16.1.21 16324 0 }
+                    }
+                }
+            }
+        }
  
 
- 
-Last note, the ``_{0}_`` part is for the port index in Marathon that this iApp should apply to.  If you have an application with only one exposed port (like the nginx app we use in the example), you just use ``F5_0_IAPP_TEMPLATE``.  If you have an application that exposes multiple ports, you can use ``F5_0_IAPP_TEMPLATE`` (and all the other ``F5_0_*`` labels) to configure one iApp for that port, and ``F5_1_IAPP_TEMPLATE`` (and ``F5_1_*``) for the next port, and so on.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,8 @@
+.. _containers-home:
+
+.. index::
+    :pair: introduction, design
+
 Introduction to F5 Container Integrations
 =========================================
 

--- a/docs/kubernetes/asp-k-deploy.rst
+++ b/docs/kubernetes/asp-k-deploy.rst
@@ -1,5 +1,7 @@
-Set up the F5 Kubernetes Proxy
-==============================
+.. _k8s-asp-deploy:
+
+Deploy the |asp| with the |aspk-long|
+=====================================
 
 .. table:: Docs test matrix
 

--- a/docs/marathon/asp-install-marathon.rst
+++ b/docs/marathon/asp-install-marathon.rst
@@ -1,7 +1,8 @@
+.. _install-aspm-marathon:
 .. _install-asp-marathon:
 
-Install the |asp| in Marathon
-=============================
+Install the |aspm-long|
+=======================
 
 .. table:: Docs test matrix
 

--- a/docs/marathon/asp-m-configure.rst
+++ b/docs/marathon/asp-m-configure.rst
@@ -1,9 +1,11 @@
 .. _aspm-configuration:
 
-Configure the |aspm-long|
-=========================
+Deploy the |asp| with the |aspm-long|
+=====================================
 
-When you launch the |aspm-long|, provide the required configuration parameter(s) and any additional default configurations you want to apply to the |asp| instances it launches.
+The |aspm-long| dynamically deploys the |asp| (ASP) in Marathon when it discovers an Application with the ``f5-asp:enable`` label.
+
+When you launch the |aspm-long|, provide the required configuration parameter(s) and any additional default configurations you want the |aspm| to apply to the ASP instances it launches.
 Define these configuration parameters in the ``"env"`` section of the |aspm| :ref:`Application definition file <install-asp-marathon>`.
 
 Required configuration parameters
@@ -20,7 +22,7 @@ MARATHON_URL            Marathon service URL (e.g., \http://10.190.25.75:8080)
 Default configurations
 ``````````````````````
 
-The |aspm-long| applies the following configurations to the |asp| by default.
+The |aspm-long| applies the following configurations to the |asp| by default. You can override any default settings using the `marathon-asp-ctlr override labels </products/connectors/marathon-asp-ctlr/latest/index.html#configuration-parameters>`_.
 
 ===========================     ===============================================
 Parameter                       Value
@@ -37,7 +39,6 @@ ASP_DEFAULT_CONTAINER           f5networks/asp:v1.0.0
 ---------------------------     -----------------------------------------------
 ASP_DEFAULT_CONTAINER_PORT      8000
 ===========================     ===============================================
-
 
 
 .. literalinclude:: /_static/config_examples/f5-marathon-asp-ctlr-example.json

--- a/docs/marathon/asp-m-virtual-servers.rst
+++ b/docs/marathon/asp-m-virtual-servers.rst
@@ -1,8 +1,9 @@
+.. _marathon-asp-deploy:
+
 Launch an |asp| instance for a Marathon Application
 ===================================================
 
-The |aspm-long| launches |asp| instances automatically for Apps that have the ``ASP_ENABLE_LABEL`` set to "enabled".
-The :ref:`default value <asp-defaults-marathon>` for ``ASP_ENABLE_LABEL`` is "asp".
+The |aspm-long| launches |asp| instances automatically for Apps that have the ``ASP_ENABLE_LABEL`` value set to "enabled" (for example, ``f5-asp:enable``).
 
 
 Launch an ASP instance with the default configurations

--- a/docs/master_toc.rst
+++ b/docs/master_toc.rst
@@ -21,6 +21,14 @@ Container Integrations Documentation
     marathon/asp*
 
 .. toctree::
+    :caption: Support
+    :glob:
+    :maxdepth: 1
+
+    releases_and_versioning
+    acknowledgements
+
+.. toctree::
     :hidden:
     :caption: Troubleshooting
     :glob:
@@ -29,12 +37,12 @@ Container Integrations Documentation
     troubleshooting/*
 
 .. toctree::
-    :caption: Support
+    :caption: Tutorials
     :glob:
     :maxdepth: 1
 
-    releases_and_versioning
-    acknowledgements
+    tutorials/*
+
 
 
 .. _tbd:

--- a/docs/tutorials/how-to-send-stats-to-Splunk.rst
+++ b/docs/tutorials/how-to-send-stats-to-Splunk.rst
@@ -1,0 +1,171 @@
+.. _send-stats-splunk:
+
+How to send statistics to Splunk
+================================
+
+The |asp| (ASP) and BIG-IP can both send data to `Splunk`_ for analysis. This tutorial leads you through the steps required to send data from BIG-IP and the ASP to a Splunk instance.
+
+Before you begin
+----------------
+
+- If you don't already have a Splunk instance, `install and configure Splunk <https://docs.splunk.com/Documentation>`_.
+
+.. rubric:: If you're sending data from a BIG-IP to Splunk:
+
+- Install and configure the :ref:`Container Connector <containers-home>` for your orchestration environment.
+
+    - :ref:`Deploy the k8s-bigip-ctlr in Kubernetes <install-kctlr>`
+    - :ref:`Install the marathon-bigip-ctlr App in Marathon <install-mctlr>`
+
+.. rubric:: If you're sending data from the ASP to Splunk:
+
+- Install and configure the |asp| as appropriate for your orchestration environment.
+
+    - :ref:`Install the ASP in Kubernetes <install-asp-k8s>`
+    - :ref:`Install the ASP in Marathon <install-asp-marathon>`
+
+.. seealso::
+
+    `Application Service Proxy Telemetry Module </products/asp/latest/index.html#telemetry>`_
+
+
+Set up Splunk to receive data
+-----------------------------
+
+#. Add a new :guilabel:`HTTP Event Collector`:
+
+    * Click on the :guilabel:`Apps` gear icon.
+    * Go to :menuselection:`Settings --> Data inputs`.
+    * :guilabel:`Add new` :guilabel:`HTTP Event Collector`.
+    * Enter a name for the collector; all other fields can use the default values.
+    * Click :guilabel:`Next`, then :guilabel:`Review`, then :guilabel:`Submit`.
+    * Record the :guilabel:`Token Value` Splunk created for your HTTP Event Collector; **you'll configure the analytics providers with this value later**.
+
+#. Enable the :guilabel:`HTTP Event Collector`:
+
+    * Go to :menuselection:`Settings --> Data inputs`.
+    * Click on :guilabel:`HTTP Event Collector`, then on :guilabel:`Global Settings`.
+    * Click on :guilabel:`Enabled`.
+    * Click :guilabel:`Save`.
+
+
+#. Configure your firewall to allow port 8088 to be open to Splunk.
+
+    .. important::
+
+        The event collector listens on port 8088 and requires HTTPS.
+
+
+#. Install the `Sankey Splunk App`_:
+
+     * In the Splunk GUI, click on :menuselection:`Apps --> Find More Apps`.
+     * Search for "Sankey".
+     * Click "Install" and enter your splunk.com credentials (this is your actual Splunk account, not the instance login).
+     * Accept the license agreement, then click the :guilabel:`Login and Install` button.
+     * Restart Splunk when prompted, then log back in.
+
+
+Send stats from BIG-IP to Splunk
+--------------------------------
+
+Use an F5 iApps template to enable stats collection on your BIG-IP and send the data to Splunk. The `F5 Analytics iApp`_ is available for download from the F5 DevCentral codeshare.
+
+Deploy the F5 Analytics iApp on the BIG-IP
+``````````````````````````````````````````
+
+Download the `F5 Analytics iApp`_ from DevCentral, then upload it to the BIG-IP using the configuration utility.
+
+#. Select :menuselection:`IApps/Templates --> Import`.
+
+#. Upload the iApp template (:file:`f5.analytics.tmpl`).
+
+#. Select :menuselection:`IApps/Application Services --> Create`.
+
+#. Choose the :file:`f5.analytics` template.
+
+#. Fill in the following fields; unspecified fields should use the default setting.
+
+    * Name - [user defined]
+    * Module HSL Streams - ``No``
+    * Local System Logging (syslog) - ``No``
+    * System SNMP Alerts - ``No``
+    * iHealth Snapshot Information - ``No``
+    * Your Facility Name - [user defined]
+    * Default Tenant - [user defined]
+    * Alternative Device Group - [user defined]
+    * IP Address or Hostname - [SPLUNK_IP]
+    * Port - ``8088``
+    * Protocol - ``HTTPS``
+    * API Key - [SPLUNK_TOKEN]
+    * Push Interval - ``20``
+    * Mapping Table: 1 - ``Type=[App Name] From=[Virtual Name] Regex= (.*)_\d  Action=Map``
+    * Mapping Table: 2 - ``Type=[Tenant Name] From=[Partition] Regex=(.*) Action=Map``
+
+#. Click :guilabel:`Finished`.
+
+.. todo:: add instructions for deployment from Kubernetes and Marathon using the iApp variables
+
+
+Send stats from the ASP to Splunk
+---------------------------------
+
+Kubernetes
+``````````
+
+#. Edit the `Service`_ annotation.
+
+    .. code-block:: bash
+
+        $ kubectl edit service <service-name>
+
+#. Add the "stats" JSON blob.
+
+    .. note::
+
+        - You must escape all quotes, as shown in the example below.
+        - Provide the URL and token for your Splunk instance.
+
+    .. code-block:: text
+
+        \"stats\": {
+          \"url\": \"splunk-url\",
+          \"token\": \"splunk-token\",
+          \"backend\": \"splunk\"
+        }
+
+
+#. Verify the change to the Service annotation.
+
+    .. code-block:: bash
+
+        $ kubectl get service <service-name>
+
+
+Marathon
+````````
+
+Add the ``ASP_DEFAULT_STATS_*`` labels to the |aspm| App.
+
+#. In the Marathon web interface, click on the |aspm| App.
+
+#. Click :guilabel:`Configuration`.
+
+#. Click :guilabel:`Edit`.
+
+#. Click :guilabel:`Labels`.
+
+#. Add the stats labels. Provide the URL and token for your Splunk instance.
+
+    .. code-block:: text
+
+        "ASP_DEFAULT_STATS_URL": "splunk-url"
+        "ASP_DEFAULT_STATS_TOKEN": "splunk-token"
+        "ASP_DEFAULT_STATS_BACKEND": "splunk"
+
+#. Click :guilabel:`Change and deploy configuration`.
+
+#. View the Applications list to verify that the STATS labels appear for all ASP-proxied Apps.
+
+
+.. _Sankey Splunk App: https://splunkbase.splunk.com/app/3112/
+.. _F5 Analytics iApp: https://devcentral.f5.com/codeshare/f5-analytics-iapp


### PR DESCRIPTION
## Headline or summary  of the issue you are fixing
@russokj 

### Fixes #116 

### Describe the problem / feature to which this change applies
Problem: We did not have any explanation of how to configure BIG-IP and the ASP to send stats to Splunk.

### Describe the change(s) made and why
Analysis: I added basic instructions for setting up Splunk, BIG-IP, Kubernetes, and Marathon. I intend to add more in-depth instructions later for Kubernetes and Marathon; these will include the correct iApp variables to define so you can deploy the F5 Analytics iApp using your BIG-IP ctlr.


