### PR TITLE
Fixes #89 - write-good complains about code blocks

### DIFF
--- a/docs/acknowledgements.rst
+++ b/docs/acknowledgements.rst
@@ -3,19 +3,19 @@ Acknowledgements and Legal Notices
 
 Copyright © 2017, F5 Networks, Inc. All rights reserved.
 
-F5 Networks, Inc. (F5) believes the information it furnishes to be accurate and reliable. However, F5 assumes no responsibility for the use of this information, nor any infringement of patents or other rights of third parties which may result from its use. No license is granted by implication or otherwise under any patent, copyright, or other intellectual property right of F5 except as specifically described by applicable user licenses. F5 reserves the right to change specifications at any time without notice.
+F5 Networks, Inc. (F5) believes the information it furnishes to be accurate and reliable. However, F5 assumes no responsibility for the use of this information, nor any infringement of patents or other rights of third parties which may result from its use. F5 grants no license by implication or otherwise under any patent, copyright, or other intellectual property right of F5 except as specifically described by applicable user licenses. F5 reserves the right to change specifications at any time without notice.
 
 Trademarks
+----------
 
 For a current list of F5 trademarks and service marks, see http://www.f5.com/about/guidelines-policies/trademarks.
 
 All other product and company names herein may be trademarks of their respective owners.
 
-
 Acknowledgements
 ----------------
 
-We hereby acknowledge the following projects that allow us to build, test, and publish the F5 Container Integrations documentation:
+We acknowledge the following projects, which we use to build, test, and publish the F5 Container Integrations documentation:
 
 
 `AWS CLI <https://aws.amazon.com/cli/>`_: written by Amazon Web Services and licensed under the `Apache 2.0 license <https://www.apache.org/licenses/LICENSE-2.0>`_.
@@ -27,7 +27,3 @@ We hereby acknowledge the following projects that allow us to build, test, and p
 `Travis-CI <https://github.com/travis-ci>`_ : developed and maintained by Travis CI GmbH and licensed under the MIT license.
 
 
-See Also
---------
-
-`BIG-IP Open Source Notices and Software Acknolwedgements <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-open-source-notices-software-acknowledgments-13-0-0/2.html>`_

--- a/docs/kubernetes/asp-k-virtual-servers.rst
+++ b/docs/kubernetes/asp-k-virtual-servers.rst
@@ -29,13 +29,13 @@ The |asp| watches Kubernetes `Service`_ definitions for a set of annotations def
 Annotate a Kubernetes Service
 -----------------------------
 
-There are a few different ways to annotate a Kubernetes `Service`_.
+Use one of the options below to annotate your Kubernetes `Service`_ and deploy the |asp|.
 
-#. Annotate the Service definition with the key-value pair ``asp.f5.com/config="<JSON-config-blob>"``.
+#. Annotate the `Service`_ definition with the key-value pair ``asp.f5.com/config="<JSON-config-blob>"``.
 
     .. important::
 
-        When you annotate the Service this way, the JSON config blob must be encoded as shown in the example below. All quotes must be escaped (``\"``).
+        When you annotate the Service this way, you must encode the JSON config blob as shown in the example below (escape all quotes -- ``\"``).
 
 
     .. code-block:: bash

--- a/docs/kubernetes/index.rst
+++ b/docs/kubernetes/index.rst
@@ -82,7 +82,7 @@ Key Kubernetes Concepts
 F5 Resource Properties
 ``````````````````````
 
-The |kctlr-long| uses special 'F5 Resources' to identify what objects it should create on the BIG-IP. An F5 resource is defined as a JSON blob in a Kubernetes `ConfigMap`_.
+The |kctlr-long| uses special 'F5 Resources' to identify what objects it should create on the BIG-IP. An F5 resource is a JSON blob included in a Kubernetes `ConfigMap`_.
 
 The :ref:`F5 Resource JSON blob <f5-resource-blob>` must contain the following properties.
 
@@ -129,11 +129,11 @@ Once you've added the BIG-IP to the OpenShift overlay network, it will have acce
 Monitors and Node Health
 ------------------------
 
-When the |kctlr-long| runs with ``pool-member-type`` set to ``nodeport`` -- the default setting -- the |kctlr| will not be aware if a node is taken down. This means that all pool members on that node would remain active even if the node itself is unavailable. When using ``nodeport`` mode, it's important to configure a health monitor so the node is marked as unhealthy if it is rebooting or otherwise unavailable.
+When the |kctlr-long| runs with ``pool-member-type`` set to ``nodeport`` -- the default setting -- the |kctlr| is not aware that Kubernetes nodes are down. This means that all pool members on a down Kubernetes node remain active even if the node itself is unavailable. When using ``nodeport`` mode, it's important to :ref:`configure a BIG-IP health monitor <k8s-config-bigip-health-monitor>` for the virtual server to mark the Kubernetes node as unhealthy if it's rebooting or otherwise unavailable.
 
-When the |kctlr-long| runs with ``pool-member-type`` set to ``cluster`` -- which integrates the BIG-IP into the cluster network -- the |kctlr-long| watches the NodeList in the Kubernetes API server; FDB (Forwarding DataBase) entries are created/updated according to that list. This ensures the |kctlr| will only make VXLAN requests to reported nodes.
+When the |kctlr-long| runs with ``pool-member-type`` set to ``cluster`` -- which integrates the BIG-IP into the cluster network -- the |kctlr-long| watches the NodeList in the Kubernetes API server. It creates/updates FDB (Forwarding DataBase) entries according to the Kubernetes NodeList. This ensures the |kctlr| only makes VXLAN requests to reported nodes.
 
-As a function of the BIG-IP VXLAN, the BIG-IP only communicates with healthy nodes. It will not attempt to route traffic to an unresponsive node, even if the node remains in the reported list.
+As a function of the BIG-IP VXLAN, the BIG-IP only communicates with healthy Kubernetes nodes. BIG-IP does not attempt to route traffic to an unresponsive node, even if the node remains in the Kubernetes NodeList.
 
 
 Related

--- a/docs/kubernetes/kctlr-configure.rst
+++ b/docs/kubernetes/kctlr-configure.rst
@@ -43,7 +43,8 @@ In addition to the required parameters noted above, you'll need to define the fo
 =====================   ===================================================
 Parameter               Description
 =====================   ===================================================
-pool-member-type        Must be set to ``cluster``
+pool-member-type        Defines the BIG-IP pool member type.
+                        This must be ``cluster`` if you're using OpenShift.
 ---------------------   ---------------------------------------------------
 openshift-sdn-name      TMOS path to the BIG-IP VXLAN tunnel providing
                         access to the Openshift SDN and Pod network;

--- a/docs/kubernetes/kctlr-secrets.rst
+++ b/docs/kubernetes/kctlr-secrets.rst
@@ -54,7 +54,9 @@ Pull an image from a private docker registry
             base64 < ~/.docker/config.json
 
 
-    - Copy the long string of characters ending in "==" into the Secret definition as the ``.dockerconfigjson`` value. (The value has been abridged in the example, indicated by ``[...]``.)
+    - Copy the long string of characters ending in "==" into the Secret definition as the ``.dockerconfigjson`` value.
+
+        .. note:: An abridged ``.dockerconfigjson`` value (indicated by ``[...]``) appears in the example below.
 
         .. literalinclude:: /_static/config_examples/f5-k8s-image-secret.yaml
             :emphasize-lines: 7

--- a/docs/kubernetes/kctlr-use-bigip-openshift.rst
+++ b/docs/kubernetes/kctlr-use-bigip-openshift.rst
@@ -96,7 +96,7 @@ Create a VXLAN on the BIG-IP
         tunnels tunnel openshift_vxlan key 0 profile vxlan-mp local-address 172.16.1.28
 
     - The ``hostIP`` address defined in the OpenShift HostSubnet is the ``local-address`` (the VTEP).
-    - The ``key`` must be set to ``0`` to give the BIG-IP access to all OpenShift subnets.
+    - The ``key`` must be ``0`` if you want to give the BIG-IP access to all OpenShift subnets.
 
 #. Verify creation of the VXLAN tunnel.
 
@@ -165,7 +165,7 @@ Assign an OpenShift overlay address to the BIG-IP
 
     .. note::
 
-        The default traffic group is used if you don't specify a traffic group when creating the selfIP.
+        If you don't specify a traffic group when creating the selfIP, it will use the default traffic group.
 
 .. [#ossdn] https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html#sdn-design-on-masters
 

--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -61,8 +61,8 @@ The |mctlr-long| is a container-based `Marathon Application`_ -- |mctlr|. You ca
 
 The |mctlr| watches the Marathon API for special "F5 Application Labels" that tell it:
 
-    a) what Application we want it to manage, and
-    b) how we want to configure the BIG-IP for that specific Application.
+    * what Application we want it to manage, and
+    * how we want to configure the BIG-IP for that specific Application.
 
 
 You can :ref:`manage BIG-IP objects <mctlr-manage-bigip-objects>` directly, or :ref:`deploy iApps <mctlr-deploy-iapps>`, with the |mctlr-long|.
@@ -89,14 +89,12 @@ See the |mctlr| `product documentation </products/connectors/marathon-bigip-ctlr
 
 
 iApps Application Labels
-````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `iApps Application Labels </products/connectors/marathon-bigip-ctlr/index.html#iapps-application-labels>`_ allow you to deploy iApps using the |mctlr-long|. The iApp you want to deploy must already exist on the BIG-IP.
+You can use the |mctlr-long| to deploy iApps on the BIG-IP using a special set of customizable iApps Application Labels. The iApp you want to deploy must already exist on the BIG-IP.
 
-A few of the key iApp Application Labels must be customized based on the iApp you want to deploy, as well as your environment and needs.
+A few of the key iApp Application Labels depend on the iApp you want to deploy, as well as your environment and needs. See :ref:`Required iApp Application Labels <marathon-required-iapp-labels>` and the `marathon-bigip-ctlr product documentation </products/connectors/marathon-bigip-ctlr/latest/>`_ for more information.
 
-- ``F5_{n}_IAPP_VARIABLE_*`` -- Custom-defined parameters that correspond to fields in the iApp template you want to launch.
-- ``F5_{n}_IAPP_POOL_MEMBER_TABLE`` -- Custom definition for the name and layout of the `Pool Member Table </products/connectors/marathon-bigip-ctlr/index.html#F5_{n}_IAPP_POOL_MEMBER_TABLE>`_ in the iApp.
 
 Apache Mesos DNS and ASP Discovery
 ``````````````````````````````````
@@ -168,7 +166,7 @@ Here, we create health checks for each of the port indices defined for our Appli
     :lineno-start: 33
 
 
-.. [#setuphealthchecks] When the ``F5_CC_USE_HEALTHCHECK`` configuration parameter is set to "True".
+.. [#setuphealthchecks] Occurs when ``F5_CC_USE_HEALTHCHECK``'s value is "True".
 
 
 
@@ -181,8 +179,8 @@ Related
     mctlr*
     asp*
 
-- `|mctlr| </products/connectors/marathon-bigip-ctlr/latest/>`_
-- `|aspm| </products/connectors/marathon-asp-ctlr/latest/>`_
+- `marathon-bigip-ctlr product documentation </products/connectors/marathon-bigip-ctlr/latest/>`_
+- `marathon-asp-ctlr product documentation </products/connectors/marathon-asp-ctlr/latest/>`_
 - `asp </products/asp/latest>`_
 
 .. _Marathon Application: https://docs.mesosphere.com/1.8/overview/concepts/#marathon-application

--- a/docs/marathon/mctlr-configure.rst
+++ b/docs/marathon/mctlr-configure.rst
@@ -33,7 +33,7 @@ F5_CC_PARTITIONS	    The BIG-IP partition |mctlr| manages
 Required Application Labels
 ---------------------------
 
-The parameter(s) listed in the table below are required :ref:`F5 application labels <app-labels>` when :ref:`directly managing BIG-IP objects <mctlr-manage-bigip-objects>`.
+Use the :ref:`F5 application labels <app-labels>` listed in the table below when you're :ref:`managing BIG-IP objects directly <mctlr-manage-bigip-objects>`.
 
 =====================   =======================================================
 Parameter               Description
@@ -52,11 +52,12 @@ F5\_{n}_PORT            Service port to use for communications with the BIG-IP
                         Example: ``"F5_0_PORT": "80"``
 =====================   =======================================================
 
+.. _marathon-required-iapp-labels:
 
 Required iApp Application Labels
 --------------------------------
 
-The parameter(s) listed in the table below are required :ref:`F5 application labels <app-labels>` when :ref:`deploying an iApp <mctlr-deploy-iapps>`.
+Use the :ref:`F5 application labels <app-labels>` when :ref:`deploying an iApp <mctlr-deploy-iapps>`.
 
 =================================   ===========================================
 Parameter                           Description

--- a/docs/marathon/mctlr-manage-bigip-objects.rst
+++ b/docs/marathon/mctlr-manage-bigip-objects.rst
@@ -34,7 +34,7 @@ Create a virtual server for a Marathon Application
 
 #. Create a JSON file containing the App service definitions and F5 labels.
 
-    .. note:: This sample App definition uses the default :ref:`port index <port-mappings>`, which is represented by ``0`` in the labels.
+    .. note:: This sample App definition shows labels that use the default :ref:`port index <port-mappings>` (``0``).
 
     .. literalinclude:: /_static/config_examples/hello-marathon-example.json
 
@@ -50,11 +50,11 @@ Create a virtual server for a Marathon Application
 
 
 
-#. Verify creation of the virtual server, pool, and member on the BIG-IP via tmsh or the configuration utility.
+#. Verify creation of the virtual server, pool, and member on the BIG-IP via ``tmsh`` or the configuration utility.
 
     .. code-block:: text
 
-        root@(host-172)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
+        root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
         ------------------------------------------------------------------
         Ltm::Virtual Server: basic-0_10.190.25.70_8080
         ------------------------------------------------------------------
@@ -69,7 +69,7 @@ Create a virtual server for a Marathon Application
 
 .. tip::
 
-    In the above example, the "Availability" is "unknown" because no health monitors are associated with the virtual server. You can add :ref:`health checks <health-checks>` to the App in Marathon; the |mctlr| will create corresponding health monitors on the BIG-IP.
+    In the above example, the "Availability" is "unknown" because there are no health monitors associated with the virtual server. You can add :ref:`health checks <health-checks>` to the App in Marathon; the |mctlr| will create corresponding health monitors on the BIG-IP.
 
 Update a virtual server
 -----------------------
@@ -84,11 +84,11 @@ Update a virtual server
         {"version":"2017-02-21T21:48:12.755Z","deploymentId":"02529d16-258b-41d4-ba06-9765c4d1f8d3"}
 
 
-#. Verify your changes are reflected on the BIG-IP via tmsh or the configuration utility.
+#. Verify your changes on the BIG-IP via ``tmsh`` or the configuration utility.
 
     .. code-block:: bash
 
-        root@(host-172)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
+        root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
 
 
 Delete a virtual server
@@ -104,12 +104,12 @@ Delete a virtual server
         {"version":"2017-02-21T21:58:11.111Z","deploymentId":"8bdf03d2-8568-46b3-a5a3-61cc397185a1"}
 
 
-#. Verify the virtual server no longer exists on the BIG-IP via tmsh or the configuration utility.
+#. Verify the virtual server no longer exists on the BIG-IP via the configuration utility.
 
     .. code-block:: bash
 
-        root@(host-172)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
-        root@(host-172)(cfg-sync Standalone)(Active)(/mesos)(tmos)#
+        root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
+        root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)#
 
 
 

--- a/docs/troubleshooting/kubernetes.rst
+++ b/docs/troubleshooting/kubernetes.rst
@@ -14,7 +14,7 @@ Verify the ASP handles traffic for a Service
     .. literalinclude:: /_static/config_examples/f5-asp-k8s-example-service.yaml
         :emphasize-lines: 10
 
-#. Send a ``curl -v`` request to the Service and view the headers to verify it was handled by the ASP. The ``X-Served-By`` line should match the IP address of an ASP pod.
+#. Send a ``curl -v`` request to the Service and view the headers to verify the ASP handled the request. The ``X-Served-By`` line should match the IP address of an ASP pod.
 
     .. code-block:: bash
         :emphasize-lines: 15

--- a/docs/troubleshooting/marathon.rst
+++ b/docs/troubleshooting/marathon.rst
@@ -9,7 +9,7 @@ Troubleshoot Your Marathon Deployment
 "InsufficientPorts" Error
 `````````````````````````
 
-If the Service Port associated with an ASP instance cannot be allocated, the ASP doesn't deploy. Common reasons for port allocation failure include the specified port already being in use or out of range. Affected tasks in the Marathon queue will display an "InsufficientPorts" error.
+If Apache Mesos can't allocate the Service Port associated with an ASP instance, the ASP won't deploy. Port allocation commonly fails because the specified port is either already in use or it's out of range. Affected tasks in the Marathon queue will display an "InsufficientPorts" error.
 
 .. rubric:: Solution:
 

--- a/scripts/test-docs.sh
+++ b/scripts/test-docs.sh
@@ -10,6 +10,6 @@ make -C docs html
 make -C docs linkcheck
 
 
-#echo "Checking grammar and style"
-#write-good docs/*.rst --weasel --so --passive --illusion --thereIs --toowordy --adverb --cliches
+echo "Checking grammar and style"
+write-good `find ./docs -name '*.rst'` --passive --so --no-illusion --thereIs --cliches || true
 


### PR DESCRIPTION
## Workaround for write-good limitations; grammar corrections
`@` mention any reviewer(s) you would like to review your work.
@michaeldayreads 

### Fixes #89

### Describe the problem / feature to which this change applies
Problem: write-good, the tool we use for grammar checking, complains about code blocks; specifically, it tends to throw errors on repeated words/numbers in code examples. Because of this, I haven't been able to run it and check the grammar for all of the site's contents.

### Describe the change(s) made and why
Analysis: I turned off the option that was triggering the repeated word errors and reactivated the write-good section of the test-docs script. I then ran the script and corrected all of the issues write-good identified.

Changes made:
- set the test-docs script to be active again and update it to check "docs/" recursively
- check and resolve grammar in docs/
- remove pip install from test-docs.sh (it's included in the container image)



