### PR TITLE
Fixes #137 - openshift landing page

### DIFF
--- a/docs/kubernetes/index.rst
+++ b/docs/kubernetes/index.rst
@@ -1,3 +1,5 @@
+.. _k8s-home:
+
 F5 Kubernetes Container Integration
 ===================================
 
@@ -14,6 +16,7 @@ The |asp| provides load balancing and telemetry for containerized applications, 
     :scale: 50 %
     :alt: F5 Container Solution for Kubernetes
 
+.. _k8s-prereqs:
 
 General Prerequisites
 ---------------------
@@ -24,6 +27,10 @@ The F5 Kubernetes Integration's documentation set assumes that you:
 - are familiar with the `Kubernetes dashboard`_ and `kubectl`_ ;
 - already have a BIG-IP :term:`device` licensed and provisioned for your requirements; [#bigipcaveat]_ and
 - are familiar with BIG-IP Local Traffic Manager (LTM) concepts and ``tmsh`` commands. [#bigipcaveat]_
+
+.. seealso::
+
+    :ref:`OpenShift Origin Prerequisites <openshift-origin-prereqs>`
 
 .. [#bigipcaveat] Not required for the |asp| and ASP controllers (|aspk|, |aspm|).
 
@@ -116,40 +123,34 @@ The backend property identifies the `Kubernetes Service`_ that makes up the serv
 Kubernetes and OpenShift Origin
 -------------------------------
 
-Red Hat's `OpenShift Origin`_ is a containerized application platform with a native Kubernetes integration. The |kctlr-long| enables use of a BIG-IP as an edge load balancer, proxying traffic from outside networks to pods inside an OpenShift cluster. OpenShift Origin uses a pod network defined by the `OpenShift SDN`_ .
-
-There are a few additional prerequisites for working with OpenShift Origin clusters that do not apply to basic Kubernetes:
-
-#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, and configmaps.
-#. You'll need to use the `OpenShift Origin CLI`_, in addition to ``kubectl``, to execute OpenShift-specific commands.
-#. To :ref:`integrate your BIG-IP into an OpenShift cluster <bigip-openshift-setup>`, you'll need to :ref:`assign an OpenShift overlay address to the BIG-IP <k8s-openshift-assign-ip>`.
-
-Once you've added the BIG-IP to the OpenShift overlay network, it will have access to all pods in the cluster. You can then use the |kctlr| the same as you would in Kubernetes.
+See :ref:`F5 OpenShift Origin Integration <openshift-home>`.
 
 Monitors and Node Health
 ------------------------
 
 When the |kctlr-long| runs with ``pool-member-type`` set to ``nodeport`` -- the default setting -- the |kctlr| is not aware that Kubernetes nodes are down. This means that all pool members on a down Kubernetes node remain active even if the node itself is unavailable. When using ``nodeport`` mode, it's important to :ref:`configure a BIG-IP health monitor <k8s-config-bigip-health-monitor>` for the virtual server to mark the Kubernetes node as unhealthy if it's rebooting or otherwise unavailable.
 
-When the |kctlr-long| runs with ``pool-member-type`` set to ``cluster`` -- which integrates the BIG-IP into the cluster network -- the |kctlr-long| watches the NodeList in the Kubernetes API server. It creates/updates FDB (Forwarding DataBase) entries according to the Kubernetes NodeList. This ensures the |kctlr| only makes VXLAN requests to reported nodes.
+.. seealso::
 
-As a function of the BIG-IP VXLAN, the BIG-IP only communicates with healthy Kubernetes nodes. BIG-IP does not attempt to route traffic to an unresponsive node, even if the node remains in the Kubernetes NodeList.
+    :ref:`OpenShift Origin node health <openshift-origin-node-health>`
 
 
 Related
 -------
 
-- `ASP product documentation`_
-- `f5-kube-proxy product documentation`_
-- `k8s-bigip-ctlr product documentation </products/connectors/k8s-bigip-ctlr/latest/>`_
+.. toctree::
+    :glob:
+
+    kctlr*
+    asp*
+    k8s-bigip-ctlr docs <http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest>
+    f5-kube-proxy docs <http://clouddocs.f5.com/products/connectors/f5-kube-proxy/latest>
+    F5 Application Service Proxy docs <http://clouddocs.f5.com/products/asp/latest>
 
 
 .. _f5-kube-proxy product documentation: </products/connectors/f5-kube-proxy/latest/>
 .. _ASP product documentation: /products/asp/latest/
-.. _OpenShift Origin: https://www.openshift.org/
-.. _OpenShift user account: https://docs.openshift.org/1.2/admin_guide/manage_users.html
-.. _OpenShift Origin CLI: https://docs.openshift.org/1.2/cli_reference/index.html
-.. _OpenShift SDN: https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html
+
 
 
 

--- a/docs/kubernetes/kctlr-app-install.rst
+++ b/docs/kubernetes/kctlr-app-install.rst
@@ -3,6 +3,15 @@
 Install the |kctlr-long|
 ========================
 
+.. table:: Docs test matrix
+
+    +-----------------------------------------------------------+
+    | kubernetes-v1.4.8_coreos.0                                |
+    +-----------------------------------------------------------+
+    | |kctlr| v1.0.0                                            |
+    +-----------------------------------------------------------+
+
+
 The |kctlr-long| installs via a `Kubernetes Deployment`_. The Deployment creates a `ReplicaSet`_ that, in turn, launches a `Pod`_ running the |kctlr| app.
 
 Before you begin
@@ -21,13 +30,16 @@ Before you begin
 
 .. _k8s-bigip-ctlr-deployment:
 
-Create a Kubernetes Deployment
-------------------------------
+Create a Deployment
+-------------------
+
+Kubernetes
+``````````
 
 Define a `Kubernetes Deployment`_ using valid JSON or YAML.
 
 .. literalinclude:: /_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
-
+    :linenos:
 
 .. tip::
 
@@ -35,13 +47,33 @@ Define a `Kubernetes Deployment`_ using valid JSON or YAML.
 
     :download:`f5-k8s-bigip-ctlr_image-secret.yaml </_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml>`
 
-    Remove the ``imagePullSecrets`` section if you are pulling the container image from a public Docker registry.
+
+OpenShift Origin
+````````````````
+
+Define an OpenShift Deployment using valid JSON or YAML.
+
+.. important::
+
+    OpenShift deployments must use the following required configuration parameters:
+
+    - ``pool-member-type=cluster``
+    - ``openshift-sdn-name=</BIG-IP-partition/BIG-IP-vxlan-tunnel>``
+
+.. literalinclude:: /_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
+    :linenos:
+
+.. tip::
+
+    You can download the example Deployment file below and modify it to suit your environment.
+
+    :download:`f5-k8s-bigip-ctlr_openshift-sdn.yaml </_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml>`
 
 
 Upload the Deployment
 ---------------------
 
-Upload the Deployment to the Kubernetes API server with the ``kubectl create`` command.
+Upload the Deployment to the Kubernetes or OpenShift API server with the ``kubectl create`` command.
 
 .. code-block:: bash
 
@@ -55,34 +87,28 @@ Verify creation
 When you create a Deployment, a `ReplicaSet`_ and `Pod`_ (s) launch automatically.
 Use ``kubectl`` to verify all of the objects launched successfully.
 
-    .. code-block:: bash
-        :emphasize-lines: 3, 7, 11
+.. code-block:: bash
+    :emphasize-lines: 3, 7, 11
 
-        user@k8s-master:~$ kubectl get deployments --namespace=kube-system
-        NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-        k8s-bigip-ctlr   1         1         1            1           1h
+    user@k8s-master:~$ kubectl get deployments --namespace=kube-system
+    NAME             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+    k8s-bigip-ctlr   1         1         1            1           1h
 
-        user@k8s-master:~$ kubectl get replicasets --namespace=kube-system
-        NAME                       DESIRED   CURRENT   AGE
-        k8s-bigip-ctlr-331478340   1         1         1h
+    user@k8s-master:~$ kubectl get replicasets --namespace=kube-system
+    NAME                       DESIRED   CURRENT   AGE
+    k8s-bigip-ctlr-331478340   1         1         1h
 
-        user@k8s-master:~$ kubectl get pods --namespace=kube-system
-        NAME                                  READY     STATUS    RESTARTS   AGE
-        k8s-bigip-ctlr-331478340-ke0h9        1/1       Running   0          1h
-        kube-apiserver-172.16.1.19            1/1       Running   0          2d
-        kube-controller-manager-172.16.1.19   1/1       Running   0          2d
-        kube-dns-v11-2a66j                    4/4       Running   0          2d
-        kube-proxy-172.16.1.19                1/1       Running   0          2d
-        kube-proxy-172.16.1.21                1/1       Running   0          2d
-        kube-scheduler-172.16.1.19            1/1       Running   0          2d
-        kubernetes-dashboard-172.16.1.19      1/1       Running   0          2d
-
-
-
-
-
+    user@k8s-master:~$ kubectl get pods --namespace=kube-system
+    NAME                                  READY     STATUS    RESTARTS   AGE
+    k8s-bigip-ctlr-331478340-ke0h9        1/1       Running   0          1h
+    kube-apiserver-172.16.1.19            1/1       Running   0          2d
+    kube-controller-manager-172.16.1.19   1/1       Running   0          2d
+    kube-dns-v11-2a66j                    4/4       Running   0          2d
+    kube-proxy-172.16.1.19                1/1       Running   0          2d
+    kube-proxy-172.16.1.21                1/1       Running   0          2d
+    kube-scheduler-172.16.1.19            1/1       Running   0          2d
+    kubernetes-dashboard-172.16.1.19      1/1       Running   0          2d
 
 .. _ReplicaSet: https://kubernetes.io/docs/user-guide/replicasets/
 .. _Pod: https://kubernetes.io/docs/user-guide/pods/
 .. _Create a new partition: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-implementations-12-1-0/29.html
-

--- a/docs/kubernetes/kctlr-configure.rst
+++ b/docs/kubernetes/kctlr-configure.rst
@@ -34,6 +34,7 @@ namespace               Kubernetes namespace to watch
     :caption: Example Deployment definition
     :emphasize-lines: 29-35
 
+.. _kctlr-configure-openshift:
 
 Required configuration parameters for OpenShift clusters
 --------------------------------------------------------

--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -178,10 +178,9 @@ Related
 
     mctlr*
     asp*
-
-- `marathon-bigip-ctlr product documentation </products/connectors/marathon-bigip-ctlr/latest/>`_
-- `marathon-asp-ctlr product documentation </products/connectors/marathon-asp-ctlr/latest/>`_
-- `asp </products/asp/latest>`_
+    marathon-bigip-ctlr docs <http://clouddocs.f5.com/products/connectors/marathon-bigip-ctlr/latest/>
+    marathon-asp-ctlr docs <http://clouddocs.f5.com/products/connectors/marathon-asp-ctlr/latest/>
+    F5 Application Service Proxy docs <http://clouddocs.f5.com/products/asp/latest>
 
 .. _Marathon Application: https://docs.mesosphere.com/1.8/overview/concepts/#marathon-application
 .. _Marathon REST API: https://mesosphere.github.io/marathon/api-console/index.html

--- a/docs/master_toc.rst
+++ b/docs/master_toc.rst
@@ -21,6 +21,13 @@ Container Integrations Documentation
     marathon/asp*
 
 .. toctree::
+    :caption: OpenShift Origin Container Integration
+    :maxdepth: 1
+    :glob:
+
+    openshift/*
+
+.. toctree::
     :caption: Support
     :glob:
     :maxdepth: 1

--- a/docs/openshift/index.rst
+++ b/docs/openshift/index.rst
@@ -1,0 +1,52 @@
+.. _openshift-home:
+
+F5 OpenShift Origin Container Integration
+=========================================
+
+Overview
+--------
+
+Red Hat's `OpenShift Origin`_ is a containerized application platform with a native Kubernetes integration. The |kctlr-long| enables use of a BIG-IP as an edge load balancer, proxying traffic from outside networks to pods inside an OpenShift cluster. OpenShift Origin uses a pod network defined by the `OpenShift SDN`_.
+
+The :ref:`F5 Kubernetes Integration doc <k8s-home>` provides an overview of how the |kctlr-long| works with Kubernetes. Because OpenShift has a native Kubernetes integration, the |kctlr-long| works the same in both environments. The |kctlr-long| does have a few :ref:`OpenShift-specific prerequisites <openshift-origin-prereqs>`, noted below.
+
+
+.. _openshift-origin-prereqs:
+
+OpenShift Prerequisites
+-----------------------
+
+The prerequisites below are in addition to the :ref:`F5 Kubernetes Integration's general prerequisites <k8s-prereqs>`.
+
+#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, and configmaps.
+#. You'll need to use the `OpenShift Origin CLI`_, in addition to ``kubectl``, to execute OpenShift-specific commands.
+#. To :ref:`integrate your BIG-IP into an OpenShift cluster <bigip-openshift-setup>`, you'll need to :ref:`assign an OpenShift overlay address to the BIG-IP <k8s-openshift-assign-ip>`.
+
+Once you've added the BIG-IP to the OpenShift overlay network, it will have access to all pods in the cluster. You can then use the |kctlr| the same as you would in Kubernetes.
+
+.. _openshift-origin-node-health:
+
+OpenShift Origin Node Health
+----------------------------
+
+In OpenShift clusters, the Kubernetes NodeList records status for all nodes registered with the master.
+
+When the |kctlr-long| runs with ``pool-member-type`` set to ``cluster`` -- which integrates the BIG-IP into the OpenShift cluster network -- it watches the NodeList in OpenShift's underlying Kubernetes API server. The |kctlr-long| creates/updates FDB (Forwarding DataBase) entries according to the NodeList. This ensures the |kctlr| only makes VXLAN requests to reported nodes.
+
+As a function of the BIG-IP VXLAN, the BIG-IP only communicates with healthy cluster nodes. BIG-IP does not attempt to route traffic to an unresponsive node, even if the node remains in the NodeList.
+
+Related
+-------
+
+.. toctree::
+    :glob:
+
+    *
+    ../kubernetes/kctlr*
+    k8s-bigip-ctlr docs <http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest>
+
+.. _OpenShift Origin: https://www.openshift.org/
+.. _OpenShift user account: https://docs.openshift.org/1.2/admin_guide/manage_users.html
+.. _OpenShift Origin CLI: https://docs.openshift.org/1.2/cli_reference/index.html
+.. _OpenShift SDN: https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html
+

--- a/docs/openshift/kctlr-use-bigip-openshift.rst
+++ b/docs/openshift/kctlr-use-bigip-openshift.rst
@@ -1,7 +1,7 @@
 .. _bigip-openshift-setup:
 
-Use BIG-IP in an OpenShift Cluster
-==================================
+Set up BIG-IP and |kctlr| for use in an OpenShift Cluster
+=========================================================
 
 .. table:: Docs test matrix
 
@@ -18,7 +18,7 @@ Steps required to set up BIG-IP and |kctlr| for use in an `OpenShift`_ cluster:
 
 #. :ref:`Create a host subnet <k8s-openshift-hostsubnet>` in your OpenShift cluster.
 #. :ref:`Create a VXLAN tunnel <k8s-openshift-vxlan-setup>` on the BIG-IP.
-#. :ref:`Assign an overlay address <k8s-openshift-assign-ip>` from the subnet to a `selfIP address`_ on the BIG-IP.
+#. :ref:`Assign an overlay address <k8s-openshift-assign-ip>` from the subnet to a `Self IP address`_ on the BIG-IP.
 #. `Create an OpenShift user account`_ for the |kctlr| with permission to manage the following:
 
     - nodes
@@ -131,7 +131,7 @@ Create a VXLAN on the BIG-IP
 Assign an OpenShift overlay address to the BIG-IP
 -------------------------------------------------
 
-#. Create a `selfIP address`_ on the BIG-IP. Use an address in the range you defined in the :ref:`HostSubnet <k8s-openshift-hostsubnet>` ``subnet`` field.
+#. Create a `Self IP address`_ on the BIG-IP. Use an address in the range you defined in the :ref:`HostSubnet <k8s-openshift-hostsubnet>` ``subnet`` field.
 
     .. code-block:: bash
 
@@ -170,17 +170,13 @@ Assign an OpenShift overlay address to the BIG-IP
 .. [#ossdn] https://docs.openshift.org/latest/architecture/additional_concepts/sdn.html#sdn-design-on-masters
 
 
+Next Steps
+----------
 
-
-
-
-
-
-
-
-
+- :ref:`Install the F5 Kubernetes BIG-IP Controller <install-kctlr>`
+- :ref:`Configure the F5 Kubernetes BIG-IP Controller for OpenShift <kctlr-configure-openshift>`
 
 .. _OpenShift: https://www.openshift.org/
 .. _Create an OpenShift user account: https://docs.openshift.org/1.2/admin_guide/manage_users.html
 .. _VXLAN profile:
-.. _selfIP address: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-1-1/5.html
+.. _Self IP address: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-1-1/5.html


### PR DESCRIPTION
## Give OpenShift its own section
@f5yacobucci 

### Fixes #137

### Describe the problem / feature to which this change applies
Problem: The clouddocs.f5.com header lists OpenShift as a Container Integration; we need a unique page to point that link to.

### Describe the change(s) made and why
Analysis: I gave OpenShift its own directory and landing page, and moved the BIG-IP config for OpenShift doc there. I edited the Kubernetes install instructions to clarify requirements for deploying in Kubernetes and OpenShift. I also fixed up the links in the 'Related' section of each integration's home page.


