### PR TITLE
Fixes #136

### DIFF
--- a/docs/acknowledgements.rst
+++ b/docs/acknowledgements.rst
@@ -8,7 +8,7 @@ F5 Networks, Inc. (F5) believes the information it furnishes to be accurate and 
 Trademarks
 ----------
 
-For a current list of F5 trademarks and service marks, see http://www.f5.com/about/guidelines-policies/trademarks.
+For a current list of F5 trademarks and service marks, see https://www.f5.com/about/guidelines-policies/trademarks.
 
 All other product and company names herein may be trademarks of their respective owners.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ rst_epilog = """
 .. _Node.js: https://nodejs.org/en/
 .. _Express: https://expressjs.com/
 .. _Splunk: https://www.splunk.com/
-.. _Mesos: https://mesosphere.com/
+.. _Apache Mesos: https://mesosphere.com/
 .. _Marathon: https://mesosphere.github.io/marathon/
 .. _Marathon Apps: https://mesosphere.github.io/marathon/docs/application-basics.html
 .. _Docker: https://www.docker.com/

--- a/docs/kubernetes/kctlr-manage-bigip-objects.rst
+++ b/docs/kubernetes/kctlr-manage-bigip-objects.rst
@@ -160,7 +160,7 @@ If you take down a Service and want to remove the corresponding BIG-IP objects, 
 Configure a BIG-IP health monitor
 `````````````````````````````````
 
-The |kctlr-long| is not aware of node health when running in the default ``nodeport`` mode. We strongly recommend configuring BIG-IP health monitors for Kubernetes Services to help ensure that |ktlcr| doesn't send traffic to unhealthy nodes.
+The |kctlr-long| is not aware of node health when running in the default ``nodeport`` mode. We strongly recommend configuring BIG-IP health monitors for Kubernetes Services to help ensure that |kctlr| doesn't send traffic to unhealthy nodes.
 
 #. Edit the Service definition.
 

--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -26,7 +26,7 @@ This documentation set assumes that you:
 - already have a BIG-IP :term:`device` licensed and provisioned for your requirements; [#bigipcaveat]_ and
 - are familiar with BIG-IP Local Traffic Manager (LTM) concepts and ``tmsh`` commands. [#bigipcaveat]_
 
-.. [#bigipcaveat] Not required for the |asp| .
+.. [#bigipcaveat] Not required for the |asp|.
 
 |asp|
 -----

--- a/scripts/test-docs.sh
+++ b/scripts/test-docs.sh
@@ -11,5 +11,4 @@ make -C docs linkcheck
 
 
 echo "Checking grammar and style"
-write-good `find ./docs -name '*.rst'` --passive --so --no-illusion --thereIs --cliches || true
-
+write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches


### PR DESCRIPTION
## Fix grammar check and minor cleanup

### Fixes #136 

### Describe the problem / feature to which this change applies
Problem: The travis builds aren't failing when they should.

### Describe the change(s) made and why
Analysis: I removed the `true` from the grammar section of the test script. I also set it to ignore the /drafts directory and fixed a few minor build issues.


