### PR TITLE
Closes #158 - IPAM documentation

### DIFF
--- a/docs/kubernetes/kctlr-configure.rst
+++ b/docs/kubernetes/kctlr-configure.rst
@@ -90,6 +90,10 @@ virtualAddress          JSON object; allocates a virtual address for the
                         port to assign to the virtualServer
 =====================   ===================================================
 
+.. note::
+ 
+   You can set ``virtualAddress.bindAddr`` :ref:`via an IPAM system <kubernetes-ipam-bind-addr>`.
+
 iApps
 `````
 

--- a/docs/kubernetes/kctlr-manage-bigip-objects.rst
+++ b/docs/kubernetes/kctlr-manage-bigip-objects.rst
@@ -146,6 +146,20 @@ Delete a virtual server
         root@(bigip)(cfg-sync Standalone)(Active)(/kubernetes)(tmos)#
 
 
+.. _kubernetes-ipam-bind-addr:
+
+Assign BIG-IP virtual server IP addresses using IPAM
+----------------------------------------------------
+
+You can use IPAM to assign an IP address to a BIG-IP virtual server. You can configure an IPAM system to set the ``virtual-server.f5.com/ip`` `annotation`_ for the ConfigMap 
+with a chosen IP address. The controller will see this ``virtual-server.f5.com/ip`` annotation and configure the BIG-IP with the specified IP address.
+
+For example: 
+
+    .. code-block:: bash
+
+        ubuntu@k8s-master:~$ kubectl annotate configmap foo virtual-server.f5.com/ip=1.2.3.4
+
 
 Connectivity for down or replaced Services
 ------------------------------------------
@@ -180,4 +194,5 @@ The |kctlr-long| is not aware of node health when running in the default ``nodep
 
 #. Verify that the health monitor exists on the BIG-IP via the configuration utility.
 
+.. _annotation: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 

--- a/docs/marathon/mctlr-configure.rst
+++ b/docs/marathon/mctlr-configure.rst
@@ -52,6 +52,10 @@ F5\_{n}_PORT            Service port to use for communications with the BIG-IP
                         Example: ``"F5_0_PORT": "80"``
 =====================   =======================================================
 
+.. note::
+
+   You can set ``F5_{n}_BIND_ADDR`` :ref:`via an IPAM system <marathon-ipam-bind-addr>`.
+
 .. _marathon-required-iapp-labels:
 
 Required iApp Application Labels

--- a/docs/marathon/mctlr-manage-bigip-objects.rst
+++ b/docs/marathon/mctlr-manage-bigip-objects.rst
@@ -111,6 +111,13 @@ Delete a virtual server
         root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)# show ltm virtual
         root@(bigip)(cfg-sync Standalone)(Active)(/mesos)(tmos)#
 
+.. _marathon-ipam-bind-addr:
 
+Assign BIG-IP virtual server IP addresses using IPAM
+----------------------------------------------------
+
+You can use IPAM to assign an IP address to a BIG-IP virtual server. You can configure an IPAM system to set the ``F5_{0}_BIND_ADDR`` label with a
+chosen IP address. The controller will configure a virtual server once it sees a valid IP address.
 
 .. _basic Hello Marathon App: https://mesosphere.github.io/marathon/docs/application-basics.html#hello-marathon-an-inline-shell-script
+


### PR DESCRIPTION
Adding documentation for IPAM support in Marathon and Kubernetes.

Fixes #158 

Problem: Need solution documentation for IPAM support added in BIGIP controllers.

Analysis: Added documentation on how a user can omit the bindAddr field and customize their IPAM system to populate this field for them with a chosen IP address.


