### PR TITLE
Fixes: #166 -- use official container image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services:
 - docker
 before_install:
-- docker pull thejodesterf5/containthedocs
+- docker pull f5devcentral/containthedocs
 install: true
 script:
 - ./scripts/docker-docs.sh ./scripts/test-docs.sh

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Build and Test
 
 The `scripts </scripts>`_ directory contains documentation testing resources. We recommend running the test script **before** opening a pull request; if the build associated with your PR doesn't pass, the request won't be accepted.
 
-The test script can be run locally or in a Docker container, which uses an image developed by F5 (https://hub.docker.com/r/thejodesterf5/containthedocs/ ). The Ubuntu-based Docker image has all of the dependencies required to build the project documentation pre-installed. If you want to run the test script locally, you'll need to install the `requirements <requirements.txt>`_ first.
+The test script can be run locally or in a Docker container, which uses an image developed by F5 (https://hub.docker.com/r/f5devcentral/containthedocs/ ). The Ubuntu-based Docker image has all of the dependencies required to build the project documentation pre-installed. If you want to run the test script locally, you'll need to install the `requirements <requirements.txt>`_ first.
 
 - scripts/docker-docs.sh -- runs a Docker container with the 'containthedocs' image.
 - scripts/test-docs.sh -- builds the documentation (``make -C docs/ html``); runs ``make linkcheck`` to check internal and external links; and checks grammar with ``write-good``. These tests run in travis-ci and must pass before we can accept a pull request.

--- a/scripts/docker-docs.sh
+++ b/scripts/docker-docs.sh
@@ -2,4 +2,4 @@
 
 set -x
 
-exec docker run --rm -it -v $PWD:$PWD --workdir $PWD -e "LOCAL_USER_ID=$(id -u)" thejodesterf5/containthedocs "$@"
+exec docker run --rm -it -v $PWD:$PWD --workdir $PWD -e "LOCAL_USER_ID=$(id -u)" f5devcentral/containthedocs "$@"


### PR DESCRIPTION
## Replace container image used for testing and deployment
`@` mention any reviewer(s) you would like to review your work.

@dangle, would you mind reviewing and merging?

### Fixes #166

### Describe the problem / feature to which this change applies
Problem: The test and deploy scripts use a container image from thejodesterf5. They should use the image from f5devcentral, which is automatically updated when changes are made to the containthedocs project.

### Describe the change(s) made and why
Analysis: The test and deploy scripts, and the project README, have been updated as appropriate.



