### PR TITLE
Fixes #170 incorrect container tag in examples

### DIFF
--- a/docs/_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
+++ b/docs/_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: k8s-bigip-ctlr
-          image: "f5networks/k8s-bigip-ctlr:v1.0.0"
+          image: "f5networks/k8s-bigip-ctlr:1.0.0"
           env:
             - name: BIGIP_USERNAME
               valueFrom:

--- a/docs/_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
+++ b/docs/_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: k8s-bigip-ctlr
-          image: "f5networks/k8s-bigip-ctlr:v1.0.0"
+          image: "f5networks/k8s-bigip-ctlr:1.0.0"
           env:
             - name: BIGIP_USERNAME
               valueFrom:


### PR DESCRIPTION
Fixes #170 

Problem:The example YAML configuration files for the k8s-bigip-ctlr deployment incorrectly uses v1.0.0 as the container tag instead of the actually 1.0.0 for our shipped containers on Docker Hub.

Reviewer: @jputrino 