### PR TITLE
Fixes #163 - Incorrect use of asp label in marathon examples

### DIFF
--- a/docs/_static/config_examples/app_asp-enabled-custom.json
+++ b/docs/_static/config_examples/app_asp-enabled-custom.json
@@ -23,7 +23,7 @@
   "mem": 128,
   // The labels below activate and configure the ASP
   "labels": {
-    "asp": "enable",
+    "f5-asp": "enable",
     "ASP_LOG_LEVEL": "debug",
     "ASP_VS_KEEP_ALIVE": 50,
     "ASP_VS_FLAGS": {

--- a/docs/_static/config_examples/app_asp-enabled-defaults.json
+++ b/docs/_static/config_examples/app_asp-enabled-defaults.json
@@ -21,7 +21,7 @@
   "mem": 128,
   // The label below activates the ASP with the default configurations
   "labels": {
-    "asp": "enable"
+    "f5-asp": "enable"
   },
   "cpus": 0.25,
   "instances": 1,

--- a/docs/marathon/asp-m-virtual-servers.rst
+++ b/docs/marathon/asp-m-virtual-servers.rst
@@ -9,7 +9,7 @@ The |aspm-long| launches |asp| instances automatically for Apps that have the ``
 Launch an ASP instance with the default configurations
 ------------------------------------------------------
 
-Add the label ``"asp": "enable"`` to the App's service definition.
+Add the label ``"f5-asp": "enable"`` to the App's service definition.
 
 #. Via the Marathon web interface:
 
@@ -40,7 +40,7 @@ Add the label ``"asp": "enable"`` to the App's service definition.
 Launch an ASP instance with custom configurations
 -------------------------------------------------
 
-Add the label ``"asp": "enable"`` to the App's service definition.
+Add the label ``"f5-asp": "enable"`` to the App's service definition.
 
 #. Via the Marathon web interface:
 

--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -79,7 +79,7 @@ In Marathon, you can `associate labels with Application tasks`_ for tracking/rep
 
 When the |mctlr-long| discovers Applications with new or updated F5 Application Labels, it dynamically creates virtual servers, pools, pool members, and HTTP :ref:`health monitors <health-checks>` for each of the Application's tasks.
 
-When the |aspm-long| discovers Applications configured with the ``"asp": "enable"`` label, it launches an ASP instance for that app. The ASP configurations are also defined with F5 Application Labels.
+When the |aspm-long| discovers Applications configured with the ``"f5-asp": "enable"`` label, it launches an ASP instance for that app. The ASP configurations are also defined with F5 Application Labels.
 
 See the |mctlr| `product documentation </products/connectors/marathon-bigip-ctlr/latest/>`_ for the full list of F5 Application Labels.
 


### PR DESCRIPTION
Fixes #163 

Problem: Documentation incorrectly uses "asp": "enable" when the default is "f5-asp":"enable" for the Marathon examples

Reviewer: @jputrino 