### PR TITLE
Need 'watch' verb for openshift permissions

### DIFF
--- a/docs/openshift/index.rst
+++ b/docs/openshift/index.rst
@@ -20,8 +20,8 @@ The prerequisites below are in addition to the :ref:`F5 Kubernetes Integration's
 
 #. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, and configmaps. Specifically, the `Verbs and Resources`_ needed are:
 
-   #. ``[get list] [nodes endpoints services]``
-   #. ``[get list update] [configmaps]``
+   #. ``[get list watch] [nodes endpoints services]``
+   #. ``[get list update watch] [configmaps]``
 
 #. You'll need to use the `OpenShift Origin CLI`_, in addition to ``kubectl``, to execute OpenShift-specific commands.
 #. To :ref:`integrate your BIG-IP into an OpenShift cluster <bigip-openshift-setup>`, you'll need to :ref:`assign an OpenShift overlay address to the BIG-IP <k8s-openshift-assign-ip>`.


### PR DESCRIPTION
Problem: Along with get, list, and update, watch is also a necessary permission needed for openshift users.

Solution: Include watch  as a verb for the proper resources.


