### PR TITLE
Fix #157: Example daemonset for ASP has the containers property incorrectly nested

### DIFF
--- a/docs/_static/config_examples/f5-asp-k8s-example-daemonset.yaml
+++ b/docs/_static/config_examples/f5-asp-k8s-example-daemonset.yaml
@@ -10,32 +10,31 @@ spec:
         name: f5-asp
     spec:
       hostNetwork: true
-      template:
-        containers:
-          - name: f5-asp
-            image: "f5networks/asp:1.0.0"
-            args:
-              # the config file is loaded from the ConfigMap; it contains the
-              # ASP global config
-              - --config-file
-              - /etc/configmap/asp.config.json
-            securityContext:
-              privileged: false
-            volumeMounts:
-            # mount a new directory
-            - name: plugin-config
-              # the path the directory will be added to; do not change
-              mountPath: /var/run/kubernetes/proxy-plugin
-              readOnly: true
-            # mount a new directory
-            - name: asp-config
-              # the path the directory will be added to; do not change
-              mountPath: /etc/configmap
-        volumes:
+      containers:
+        - name: f5-asp
+          image: "f5networks/asp:1.0.0"
+          args:
+            # the config file is loaded from the ConfigMap; it contains the
+            # ASP global config
+            - --config-file
+            - /etc/configmap/asp.config.json
+          securityContext:
+            privileged: false
+          volumeMounts:
+          # mount a new directory
           - name: plugin-config
-            hostPath:
-              path: /var/run/kubernetes/proxy-plugin
+            # the path the directory will be added to; do not change
+            mountPath: /var/run/kubernetes/proxy-plugin
+            readOnly: true
+          # mount a new directory
           - name: asp-config
-            # replace with name of your ASP ConfigMap
-            configMap:
-              name: f5-asp-config
+            # the path the directory will be added to; do not change
+            mountPath: /etc/configmap
+      volumes:
+        - name: plugin-config
+          hostPath:
+            path: /var/run/kubernetes/proxy-plugin
+        - name: asp-config
+          # replace with name of your ASP ConfigMap
+          configMap:
+            name: f5-asp-config


### PR DESCRIPTION
Problem: The example ASP deployment DaemonSet is an invalid spec for a
DaemonSet, because it places the "containers" property inside of an
extra "template" property.  It suggests
spec->template->spec->template->containers, whereas
spec->template->spec->containers is correct.

Analysis: Delete the extra "template" level.

Fixes #157 
