### PR TITLE
Update description of namespace flag

### DIFF
--- a/docs/kubernetes/kctlr-configure.rst
+++ b/docs/kubernetes/kctlr-configure.rst
@@ -26,7 +26,9 @@ bigip-partition         The BIG-IP partition |kctlr| manages
 ---------------------   ---------------------------------------------------
 kubeconfig              Path to the `kubeconfig`_ file
 ---------------------   ---------------------------------------------------
-namespace               Kubernetes namespace to watch
+namespace               Kubernetes namespace to watch, as of v1.1.0 this is
+                        no longer required and if left blank the
+                        controller will watch all namespaces
 =====================   ===================================================
 
 
@@ -91,7 +93,7 @@ virtualAddress          JSON object; allocates a virtual address for the
 =====================   ===================================================
 
 .. note::
- 
+
    You can set ``virtualAddress.bindAddr`` :ref:`via an IPAM system <kubernetes-ipam-bind-addr>`.
 
 iApps


### PR DESCRIPTION
Problem:Docs show namespace being required

Solution: Update docs to show namepsace flag is no longer required
and we have a default of watching all namespaces

Fixes #181 

