### PR TITLE
Fix incorrect highlighting of config examples

### DIFF
--- a/docs/kubernetes/asp-k-virtual-servers.rst
+++ b/docs/kubernetes/asp-k-virtual-servers.rst
@@ -44,6 +44,7 @@ Use one of the options below to annotate your Kubernetes `Service`_ and deploy t
       user@k8s-master:~$ kubectl edit service example-service
 
    .. literalinclude:: /_static/config_examples/f5-asp-k8s-example-service.yaml
+      :linenos:
       :emphasize-lines: 4-13
 
    :download:`Download an example Service definition with the ASP annotation </_static/config_examples/f5-asp-k8s-example-service.yaml>`

--- a/docs/kubernetes/kctlr-configure.rst
+++ b/docs/kubernetes/kctlr-configure.rst
@@ -35,7 +35,8 @@ namespace               Kubernetes namespace to watch [#fnnamespace]_
 
 .. literalinclude:: /_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
    :caption: Example Deployment definition
-   :emphasize-lines: 29-35
+   :linenos:
+   :emphasize-lines: 32-35, 43
 
 .. _kctlr-configure-openshift:
 
@@ -62,7 +63,8 @@ openshift-sdn-name      TMOS path to the BIG-IP VXLAN tunnel providing
 
 .. literalinclude:: /_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
    :caption: Example Deployment definition
-   :emphasize-lines: 29-38
+   :linenos:
+   :emphasize-lines: 30-33, 41-43
 
 
 Required configuration parameters for F5 resources

--- a/docs/kubernetes/kctlr-deploy-iapp.rst
+++ b/docs/kubernetes/kctlr-deploy-iapp.rst
@@ -31,7 +31,7 @@ The example F5 resource JSON blob shown below defines the ``f5.http`` iApp. The 
 .. literalinclude:: /_static/config_examples/f5-resource-vs-iApp-example.json
     :caption: Example F5 iApp Resource definition
     :linenos:
-    :emphasize-lines: 8-29
+    :emphasize-lines: 8-30
 
 
 :download:`Download f5-resource-vs-iApp-example.json </_static/config_examples/f5-resource-vs-iApp-example.json>`

--- a/docs/kubernetes/kctlr-manage-bigip-objects.rst
+++ b/docs/kubernetes/kctlr-manage-bigip-objects.rst
@@ -182,7 +182,7 @@ Configure BIG-IP LTM health monitors for Kubernetes Services to help ensure that
 
    .. literalinclude:: /_static/config_examples/f5-resource-vs-example.configmap.yaml
       :linenos:
-      :emphasize-lines: 22-26
+      :emphasize-lines: 27-32
 
 #. Use the BIG-IP configuration utility to verify that the health monitor exists.
 

--- a/docs/kubernetes/kctlr-secrets.rst
+++ b/docs/kubernetes/kctlr-secrets.rst
@@ -56,7 +56,7 @@ Pull an image from a private docker registry
      .. note:: An abridged ``.dockerconfigjson`` value (indicated by ``[...]``) appears in the example below.
 
      .. literalinclude:: /_static/config_examples/f5-k8s-image-secret.yaml
-        :emphasize-lines: 7
+        :emphasize-lines: 8
 
 2. Verify the Secret exists.
 
@@ -85,7 +85,7 @@ Pull an image from a private docker registry
 
    .. literalinclude:: /_static/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
       :caption: ``k8s-bigip-ctlr`` Deployment
-      :emphasize-lines: 36-37
+      :emphasize-lines: 45-46
 
 
 

--- a/docs/marathon/asp-install-marathon.rst
+++ b/docs/marathon/asp-install-marathon.rst
@@ -28,7 +28,7 @@ Deploy the |aspm-long| using the Marathon REST API
 
    .. literalinclude:: /_static/config_examples/f5-marathon-asp-ctlr-example.json
       :linenos:
-      :emphasize-lines: 9, 17-31
+      :emphasize-lines: 9, 17-32
 
    .. tip::
 

--- a/docs/marathon/asp-m-configure.rst
+++ b/docs/marathon/asp-m-configure.rst
@@ -44,7 +44,8 @@ ASP_DEFAULT_CONTAINER_PORT      8000
 
 .. literalinclude:: /_static/config_examples/f5-marathon-asp-ctlr-example.json
    :caption: Example Application definition
-   :emphasize-lines: 17-31
+   :linenos:
+   :emphasize-lines: 18-32
 
 
 See Also

--- a/docs/marathon/asp-m-virtual-servers.rst
+++ b/docs/marathon/asp-m-virtual-servers.rst
@@ -34,7 +34,7 @@ Add the label ``"f5-asp": "enable"`` to the App's service definition.
 
    .. literalinclude:: /_static/config_examples/app_asp-enabled-defaults.json
       :linenos:
-      :emphasize-lines: 21-24
+      :emphasize-lines: 22-25
 
 
    - Send a PUT request to the Marathon API server to update the App.
@@ -63,7 +63,7 @@ Add the label ``"f5-asp": "enable"`` to the App's service definition.
    - Add your desired `override labels </products/connectors/marathon-asp-ctlr/latest/index.html#configuration-parameters>`_ to the App's service definition.
 
      .. literalinclude:: /_static/config_examples/app_asp-enabled-custom.json
-        :emphasize-lines: 6-8, 23-31
+        :emphasize-lines: 6-8, 24-34
         :linenos:
 
    - Send a PUT request to the Marathon API server to update the App definition.

--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -159,9 +159,9 @@ The code sample below defines an Application with three (3) port indices.
 
 .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example_pm_hc.json
    :caption: Service definition with multiple ports
-   :lines: 1-24
+   :lines: 1-25
    :linenos:
-   :emphasize-lines: 13-15, 16-18, 19-21
+   :emphasize-lines: 13-23
 
 
 In the ``labels`` section, we specify that we want to create HTTP virtual servers on the BIG-IP device for port indices ``0`` and ``1``.
@@ -169,8 +169,8 @@ In this example, ``0`` refers to the first mapping defined above (``"containerPo
 
 .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example_pm_hc.json
    :caption: |mctlr| labels defining BIG-IP objects for two (2) port indices
-   :lines: 25-33
-   :lineno-start: 25
+   :lines: 26-40
+   :lineno-start: 26
 
 .. [#dockerbridge] See the `Docker Networking <https://docs.docker.com/engine/userguide/networking/>`_ documentation for more information.
 
@@ -191,8 +191,8 @@ Here, we create health checks for each of the port indices defined for our Appli
 
 .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example_pm_hc.json
    :caption: Defining health checks for multiple ports
-   :lines: 33-61
-   :lineno-start: 33
+   :lines: 41-66
+   :lineno-start: 41
 
 
 .. [#setuphealthchecks] Occurs when ``F5_CC_USE_HEALTHCHECK``'s value is "True".

--- a/docs/marathon/mctlr-app-install.rst
+++ b/docs/marathon/mctlr-app-install.rst
@@ -28,7 +28,7 @@ Launch the |mctlr| App using the Marathon REST API
 
    .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example.json
       :linenos:
-      :emphasize-lines: 9, 13-24
+      :emphasize-lines: 12, 16-27
 
    .. tip::
 

--- a/docs/marathon/mctlr-authenticate-dcos.rst
+++ b/docs/marathon/mctlr-authenticate-dcos.rst
@@ -73,6 +73,6 @@ DC/OS Enterprise
 #. Add the ``F5_CC_DCOS_AUTH_CREDENTIALS`` and ``F5_CC_MARATHON_CA_CERT`` `Marathon BIG-IP Controller configuration labels </products/connectors/marathon-bigip-ctlr/latest/#configuration-parameters>`_ to the |mctlr| App definition.
 
    .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example.json
-      :lines: 1-21, 24-26
+      :lines: 1-18, 22-26
       :linenos:
-      :emphasize-lines: 20-21
+      :emphasize-lines: 19-21

--- a/docs/marathon/mctlr-configure.rst
+++ b/docs/marathon/mctlr-configure.rst
@@ -27,7 +27,7 @@ F5_CC_PARTITIONS	    The `BIG-IP partition`_ |mctlr| should manage
 
 .. literalinclude:: /_static/config_examples/f5-marathon-bigip-ctlr-example.json
    :caption: Example Application definition
-   :emphasize-lines: 13-18
+   :emphasize-lines: 17-21
    :linenos:
 
 Required Application Labels

--- a/docs/openshift/kctlr-use-bigip-openshift.rst
+++ b/docs/openshift/kctlr-use-bigip-openshift.rst
@@ -50,7 +50,7 @@ Define a HostSubnet using valid JSON or YAML.
 
 .. literalinclude:: /_static/config_examples/f5-kctlr-openshift-hostsubnet.yaml
    :linenos:
-   :emphasize-lines: 5-15
+   :emphasize-lines: 5-7, 9-18
 
 :download:`Download the example </_static/config_examples/f5-kctlr-openshift-hostsubnet.yaml>`
 

--- a/docs/troubleshooting/kubernetes.rst
+++ b/docs/troubleshooting/kubernetes.rst
@@ -12,7 +12,8 @@ Verify the ASP handles traffic for a Service
 #. Add the ``x-served-by`` flag to the `asp.config` annotation in the Service definition:
 
    .. literalinclude:: /_static/config_examples/f5-asp-k8s-example-service.yaml
-      :emphasize-lines: 10
+      :linenos:
+      :emphasize-lines: 12
 
 #. Send a ``curl -v`` request to the Service and view the headers to verify the ASP handled the request.
    The ``X-Served-By`` line should match the IP address of an ASP pod.


### PR DESCRIPTION
Problem:
Incorrect highlighting and splitting of marathon config example

Solution:
- Fixed the incorrect highlighting and splitting of the marathon
config example
- Inspected all other highlights and fixed several of those

Testing:
Inspected highlightling on local preview to check for correctness.

Fixes #197


## Headline or summary  of the issue you are fixing
`@` mention any reviewer(s) you would like to review your work.

### Reference the `#<issueid>` 
If your PR does not correspond to an existing Issue, create one before moving forward.

Fixes #<issueid>

### Describe the problem / feature to which this change applies
Problem:

### Describe the change(s) made and why
Analysis:


