### PR TITLE
Update OpenShift docs to mention correct resources

### DIFF
--- a/docs/openshift/index.rst
+++ b/docs/openshift/index.rst
@@ -22,7 +22,7 @@ OpenShift Prerequisites
 
 The prerequisites below are in addition to the :ref:`F5 Kubernetes Integration's general prerequisites <k8s-prereqs>`.
 
-#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, and configmaps.
+#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, configmaps, ingresses, and events.
    Add the verbs and resources shown below to your `Authorization Policy`_:
 
    #. ``[get list watch] [nodes endpoints services namespaces ingresses]``


### PR DESCRIPTION
Problem: The verbs/resources lists have been properly updated for Ingress,
 but the sentence describing these lists has not been updated.

Solution: Add ingresses and events to the description of what resources to manage.

Fixes #220