### PR TITLE
Update OpenShift docs to mention correct resources

### DIFF
--- a/docs/openshift/index.rst
+++ b/docs/openshift/index.rst
@@ -22,8 +22,8 @@ OpenShift Prerequisites
 
 The prerequisites below are in addition to the :ref:`F5 Kubernetes Integration's general prerequisites <k8s-prereqs>`.
 
-#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, and configmaps.
-   Add the verbs and resources shown below to your `Authorization Policy`_:
+#. The |kctlr-long| needs an `OpenShift user account`_ with permission to access nodes, endpoints, services, configmaps, ingresses, ingresses/status,
+and events. Add the verbs and resources shown below to your `Authorization Policy`_:
 
    #. ``[get list watch] [nodes endpoints services namespaces ingresses]``
    #. ``[get list watch update create patch] [configmaps ingresses/status events]``

--- a/docs/openshift/kctlr-use-bigip-openshift.rst
+++ b/docs/openshift/kctlr-use-bigip-openshift.rst
@@ -26,6 +26,8 @@ Steps required to set up a BIG-IP device and |kctlr| for use in an `OpenShift`_ 
    - configmaps
    - namespaces
    - ingresses
+   - ingresses/status
+   - events
 
 .. note::
 


### PR DESCRIPTION
Problem: The verbs/resources lists have been properly updated for Ingress,
 but there are still a few missing pieces to describe these resources.

Solution: Add ingresses and events to the descriptions of what resources to manage.

Fixes #220