### PR TITLE
Fix OpenShift example configs

### DIFF
--- a/docs/_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
+++ b/docs/_static/config_examples/f5-k8s-bigip-ctlr_openshift-sdn.yaml
@@ -11,8 +11,8 @@ spec:
       labels:
         app: k8s-bigip-ctlr
     spec:
-      containers:
       serviceAccountName: bigip-ctlr
+      containers:
         - name: k8s-bigip-ctlr
           image: "f5networks/k8s-bigip-ctlr:1.1.0"
           env:

--- a/docs/_static/config_examples/f5-kctlr-openshift-clusterrole-binding.yaml
+++ b/docs/_static/config_examples/f5-kctlr-openshift-clusterrole-binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
     name: bigip-ctlr-role
 userNames:
-- system:serviceaccount:default:bigip-ctlr
+- system:serviceaccount:kube-system:bigip-ctlr
 subjects:
 - kind: ServiceAccount
   namespace: kube-system


### PR DESCRIPTION
Problem: There were a couple issues in some OpenShift example config files. One file
used the wrong namespace in a definition. Another file had some deployment fields out
of order.

Solution: Fix these two example files to have the correct fields.

Fixes https://github.com/F5Networks/k8s-bigip-ctlr/issues/370, Fixes https://github.com/F5Networks/k8s-bigip-ctlr/issues/369