### PR TITLE
Solution docs are inaccurate and contain extraneous information

### DIFF
--- a/docs/_static/config_examples/manifest.yaml
+++ b/docs/_static/config_examples/manifest.yaml
@@ -6,56 +6,33 @@ applications:
       BIGIP_CTLR_CFG: |
                       bigip:
                         url: https://1.2.3.4
-                        user: myUsername
-                        pass: myPassword
+                        user: <myUsername>
+                        pass: <myPassword>
                         partition:
                           - cf
                         balance: round-robin
-                        verify_interval: 1000000
+                        verify_interval: 30
                         external_addr: 10.100.100.101
-                        policies:
-                          prerouting:
-                            - /Common/bigip-traffic
-                        health_monitors:
-                          - /Common/tcp_half_open
 
+                      route_mode: all
 
-                      status:
-                        user: admin
-                        pass: admin
                       nats:
                         - host: 10.100.100.25
                           port: 4222
-                          user: nats
-                          pass: "myNatsPassword"
+                          user: <myNatsUser>
+                          pass: <myNatsPassword>
 
                       logging:
-                        file: /tmp/cf-bigip.ctlr.log
-                        syslog: vcap.cf-bigip-ctlr
-                        level: debug
-                        loggregator_enabled: false
-                        metron_address: "localhost:3457"
-
-                      go_max_procs: -1
-                      prune_stale_droplets_interval: 30s
-                      droplet_stale_threshold: 120s
-                      suspend_pruning_if_nats_unavailable: false
+                        level: info
 
                       oauth:
-                        token_endpoint: uaa.service.cf.internal
-                        client_name: "gorouter"
-                        client_secret: <myGoRouterSecret>
-                        port: 8443
+                        token_endpoint: uaa.system.cf.local
+                        client_name: <myAdminUser>
+                        client_secret: <myAdminSecret>
+                        port: 443
                         skip_ssl_validation: true
-                        ca_certs:
 
-                          #routing_api:
-                          #uri: http://routing-api.service.cf.internal
-                          #port: 3000
-                          #auth_disabled: false
-
-                      start_response_delay_interval: 20s
-
-                      token_fetcher_max_retries: 3
-                      token_fetcher_retry_interval: 5s
-                      token_fetcher_expiration_buffer_time: 30
+                      routing_api:
+                        uri: http://api.system.cf.local
+                        port: 80
+                      auth_disabled: false

--- a/docs/cloudfoundry/cfctlr-app-install.rst
+++ b/docs/cloudfoundry/cfctlr-app-install.rst
@@ -1,11 +1,9 @@
 .. _deploy-cf-ctlr:
 
-.. include:: /_static/reuse/beta-announcement-cf.rst
+Deploy the BIG-IP Controller for Cloud Foundry
+==============================================
 
-Deploy the BIG-IP Controller for Cloud Foundry :fonticon:`fa fa-wrench`
-=======================================================================
-
-This document describes the steps required to deploy the |cf-long| in `Cloud Foundry`_ or `Pivotal Cloud Foundry`_ using an `Application Manifest`_.
+Complete the steps provided below to deploy the |cf-long| in `Cloud Foundry`_ or `Pivotal Cloud Foundry`_ using an `Application Manifest`_.
 
 .. _cf-deployment-prereqs:
 
@@ -13,25 +11,34 @@ Before you begin
 ----------------
 
 - `Enable Docker in Cloud Foundry`_ :fonticon:`fa fa-external-link`.
-- `Create a read-only Admin user in Cloud Foundry`_ :fonticon:`fa fa-external-link` (needs "routing.routes.read" permission).
+- `Create a read-only Admin user in Cloud Foundry`_ :fonticon:`fa fa-external-link` (needs "routing.routes.read" and "routing.router_groups.read" permissions).
 - `Add the BIG-IP device to Cloud Foundry`_ :fonticon:`fa fa-external-link` as a custom load balancer.
 
 .. _create-application-manifest:
 
-Create an Application Manifest
+Create an application manifest
 ------------------------------
 
-Create a new Application Manifest file defining the |cf-long| `configuration parameters </products/connectors/cf-bigip-ctlr/latest/index.html#configuration-parameters>`_ you want to apply for your cloud.
+Create a new Application Manifest file defining the |cfctlr| `configuration parameters </products/connectors/cf-bigip-ctlr/latest/index.html#configuration-parameters>`_ you want to apply for your cloud.
 
 The :code:`bigip` section of the example |cfctlr| manifest below does the following:
 
 - provides the IP address and user account credentials for the BIG-IP device;
 - defines the existing BIG-IP partition in which |cfctlr| should create objects;
-- sets the load balancing method for the virtual server to round-robin;
-- sets the interval at which the |cfctlr| attempts to verify BIG-IP settings;
-- assigns an external IP address to the virtual server;
-- assigns an existing BIG-IP traffic policy (:code:`/Common/bigip-traffic`) to the virtual server; and
-- assigns an existing BIG-IP health monitor (:code:`/Common/tcp_half_open`) to the virtual server.
+- sets the load balancing method desired for all pools created by the |cfctlr|;
+- sets the interval at which the |cfctlr| attempts to verify BIG-IP settings; and
+- assigns an external IP address to the virtual server.
+
+.. note::
+
+   - To support L7 (HTTP) routing, you must include the :code:`nats` section in the Controller manifest.
+   - To support L4 (TCP) routing, you must define the following sections:
+
+      * :code:`routing_api` (REQUIRED)
+      * :code:`oauth`  (REQUIRED)
+      * :code:`route_mode`  (OPTIONAL)
+
+   See the |cfctlr| `configuration parameters </products/connectors/cf-bigip-ctlr/v1.0/#configuration-parameters>`_ table for more information.
 
 .. literalinclude:: /_static/config_examples/manifest.yaml
    :linenos:
@@ -42,30 +49,42 @@ The :code:`bigip` section of the example |cfctlr| manifest below does the follow
 
 .. tip::
 
-   If you want to use "x-forwarded-for" and "x-forwarded-proto" headers, add a BIG-IP traffic policy for each before you launch the |cfctlr| app.
-   Add the :code:`policies` configuration parameter to the Application Manifest to assign the policies to the virtual server(s).
+   If you want to use the "x-forwarded-for" and "x-forwarded-proto" headers, take the steps below **before** you launch the |cfctlr| app:
 
+   #. Add a BIG-IP profile with "x-forwarded-for" enabled.
+   #. Add a BIG-IP traffic policy to set the "x-forwarded-proto" header.
+   #. Add these objects to the Application Manifest using the :code:`profiles` and :code:`policies` configuration parameters, respectively.
 
-Push the |cfctlr| App to Cloud Foundry
+Push the |cfctlr| app to Cloud Foundry
 --------------------------------------
 
 Use the `Cloud Foundry CLI`_ :command:`cf push` command to deploy the |cfctlr| App.
 
 .. code-block:: console
 
-   cf push -o https://hub.docker.com/r/f5networks/cf-bigip-ctlr/ -f manifest.yaml
+   cf push -o f5networks/cf-bigip-ctlr -f manifest.yaml
 
-Verify Creation of BIG-IP Objects
+Verify creation of BIG-IP objects
 ---------------------------------
+
+Virtual Servers
+```````````````
+
+The |cf-long| creates and manages BIG-IP virtual servers. You should see one (1) virtual server per TCP route configured in your Cloud Foundry
+deployment. You should also have at least one (1) virtual server handling unencrypted HTTP traffic on port 80. If the configuration manifest contains an SSL profile, the Controller creates another L7 virtual server on port 443.
+
+#. Log in to the BIG-IP configuration utility at the management IP address (for example, :code:`https://10.90.25.228/xui`).
+#. Choose the configured partition ("cf" in our examples) from the :guilabel:`Partition` dropdown menu.
+#. Go to :menuselection:`Local Traffic --> Virtual Servers` to view the virtual server(s) created in the partition.
 
 Policies
 ````````
 
 The |cf-long| turns Cloud Foundry route tables into BIG-IP Local Traffic policies.
-You should see a new policy on your BIG-IP device (there will be two if you're using https), with a rule for each route in your Cloud Foundry deployment.
+You should see a new policy on your BIG-IP device, with a rule for each route in your Cloud Foundry deployment.
 
 #. Log in to the BIG-IP configuration utility at the management IP address (for example, :code:`https://10.190.25.228/xui`).
-#. Choose the "cf" partition from the :guilabel:`Partition` dropdown menu.
+#. Choose the configured partition ("cf" in our examples) from the :guilabel:`Partition` dropdown menu.
 #. Go to :menuselection:`Local Traffic --> Policies` to view a list of all policies in the partition.
 
 Pools
@@ -76,10 +95,10 @@ The |cf-long| also creates a pool and pool members for every route in your Cloud
 You can use the BIG-IP configuration utility to verify that the pools and pool members exist.
 
 #. Log in to the BIG-IP configuration utility at the management IP address (for example, :code:`https://10.190.25.228/xui`).
-#. Choose the "cf" partition from the :guilabel:`Partition` dropdown menu.
+#. Choose the configured partition ("cf" in our examples) from the :guilabel:`Partition` dropdown menu.
 #. Go to :menuselection:`Local Traffic --> Pools` to view a list of all pools in the partition.
 
 
-.. _Enable Docker in Cloud Foundry: https://docs.cloudfoundry.org/adminguide/docker.html#run-monitor
+.. _Enable Docker in Cloud Foundry: https://docs.cloudfoundry.org/adminguide/docker.html#enable
 .. _Create a read-only Admin user in Cloud Foundry: https://docs.cloudfoundry.org/concepts/roles.html
 .. _Add the BIG-IP device to Cloud Foundry: https://docs.pivotal.io/pivotalcf/1-7/opsguide/custom-load-balancer.html

--- a/docs/cloudfoundry/index.rst
+++ b/docs/cloudfoundry/index.rst
@@ -1,7 +1,7 @@
 .. _cf-home:
 
-F5 Cloud Foundry Container Integration :fonticon:`fa fa-wrench`
-===============================================================
+F5 Cloud Foundry Container Integration
+======================================
 .. _cf-overview:
 
 Overview
@@ -9,11 +9,11 @@ Overview
 
 .. include:: /_static/reuse/beta-announcement-cf.rst
 
-The F5 Container Integration for `Cloud Foundry`_  consists of the `F5 BIG-IP Controller for Cloud Foundry </products/connectors/cf-bigip-ctlr/latest>`_.
+The F5 Container Integration for `Cloud Foundry`_ consists of the `F5 BIG-IP Controller for Cloud Foundry </products/connectors/cf-bigip-ctlr/latest>`_.
 
-The |cf-long| configures BIG-IP Local Traffic Manager (LTM) objects for Cloud Foundry applications, serving North-South traffic.
+The |cf-long| lets you use your F5 BIG-IP device as an Application Delivery Controller (ADC) in Cloud Foundry, serving North-South traffic.
 
-You can use the |cf-long| with `Cloud Foundry`_ or `Pivotal Cloud Foundry`_ (PCF).
+You can use the |cfctlr| with `Cloud Foundry`_ or `Pivotal Cloud Foundry`_ (PCF).
 
 .. _cf-prereqs:
 
@@ -34,22 +34,25 @@ The F5 Integration for Cloud Foundry's documentation set assumes that you:
 The |cf-long| is a Docker container-based application that runs on a Cloud Foundry `Diego cell`_.
 
 You can :ref:`deploy the F5 BIG-IP Controller for Cloud Foundry <deploy-cf-ctlr>` using an `Application Manifest`_.
-The Application Manifest tells the |cf-long|
+The Application Manifest tells Cloud Foundry and the |cfctlr|
 
-- how to log in to the BIG-IP device, and
-- how to set up the BIG-IP device when you launch the |cfctlr| for the first time.
+- how to deploy the |cfctlr| into the Cloud Foundry environment,
+- how to log in to the BIG-IP device,
+- how to set up the BIG-IP device when you launch the |cfctlr| for the first time, and
+- how to access orchestration information from the environment.
 
 Once the |cf-long| is running, it
 
-- creates a BIG-IP virtual server, which serves as the entry point for traffic into the cloud;
-- creates a `BIG-IP Local Traffic policy`_ (maximum of two - one each for http and https) with rules for each route it finds in Cloud Foundry;
-- creates a pool for each route, with members for each application instance;
+- creates BIG-IP virtual servers, which serve as the entry points for traffic into the cloud;
+- creates a `BIG-IP Local Traffic policy`_ with rules for each HTTP route it finds in Cloud Foundry;
+- creates a pool for each TCP and HTTP route, with members for each application instance;
 - associates each application's traffic policy rule with its pool.
 
 .. attention::
 
-   The |cf-long| can create a maximum of two (2) virtual servers for Cloud Foundry: one (1) for HTTP and one (1) for HTTPS.
-   The |cf-long| creates an HTTP virtual server by default.
+   - The |cfctlr| can create two (2) L7 virtual servers for Cloud Foundry: one (1) for HTTP and one (1) for HTTPS.
+   - The |cfctlr| creates an HTTP virtual server by default.
+   - The |cfctlr| creates an L4 (TCP) virtual server for each mapped route to a TCP domain.
 
 
 .. _cf-key-concepts:
@@ -57,19 +60,23 @@ Once the |cf-long| is running, it
 Key Cloud Foundry Concepts
 --------------------------
 
-|cf-long| configurations are "global", meaning a single set of configurations apply to all of the pools/pools members created for Cloud Foundry Apps.
+The |cfctlr| configurations are "global", meaning a single set of configurations apply to all of the pools/pool members created for Cloud Foundry Routes and Applications.
 The Cloud Foundry :ref:`Application Manifest <create-application-manifest>` file is the means via which you can identify the BIG-IP policies, profiles, etc., you want to apply.
+
+.. important::
+
+   Some policy and profile configurations only apply to L7 (HTTP) virtual servers. See the `configuration parameters </products/connectors/cf-bigip-ctlr/latest/index.html#configuration-parameters>`_ table for more information.
 
 .. _cf-gorouter-nats:
 
-Gorouter and NATS
-`````````````````
+Routes, NATS, and Routing API
+`````````````````````````````
 
-In Cloud Foundry, the `Gorouter`_ component routes all incoming traffic.
-Similarly, the |cf-long| uses Cloud Foundry's routing tables to direct traffic to the correct Diego cell virtual machine(s) for a requested application.
-The |cf-long| watches the `NATS bus`_ for route updates; when it discovers changes, it configures the BIG-IP device(s) accordingly.
+In Cloud Foundry, the `Gorouter`_ component routes all incoming L7 traffic. The `TCP Router`_ component routes all incoming L4 traffic.
+Similarly, the |cfctlr| uses Cloud Foundry's routing tables to direct traffic to the correct virtual machine(s) for a requested application.
+The |cfctlr| watches the `NATS bus`_ and `Routing API`_ for route updates; when the Controller discovers changes, it configures the BIG-IP device(s) accordingly.
 
-When you deploy a new application in Cloud Foundry, the |cf-long| automatically creates a BIG-IP pool, pool members, and traffic policy rule for the new route.
+When you deploy a new application with a mapped HTTP route in Cloud Foundry, the |cfctlr| automatically creates a BIG-IP pool, pool members, and traffic policy rule for the new route. When you deploy a new application with a mapped TCP route in Cloud Foundry, the |cfctlr| automatically creates a BIG-IP virtual server, pool, and pool members for the new route.
 
 .. seealso::
 
@@ -82,15 +89,16 @@ When you deploy a new application in Cloud Foundry, the |cf-long| automatically 
 BIG-IP Local Traffic Manager Services
 -------------------------------------
 
-You can apply existing BIG-IP health monitors, policies, and SSL profiles to the virtual server(s) and pools the |cf-long| creates.
-Likewise, you can select any load balancing mode that exists on the BIG-IP device.
+You can apply existing BIG-IP health monitors, policies, profiles, and SSL profiles to the virtual server(s) and pools the |cfctlr| creates for HTTP routes (these configurations do not apply to objects managed for TCP routes).
+Likewise, you can select any BIG-IP load balancing mode (applies to both HTTP and TCP pools).
 Define the |cfctlr| `configuration parameters </products/connectors/cf-bigip-ctlr/latest/index.html#configuration-parameters>`_ in your :ref:`Application Manifest <create-application-manifest>`.
 
 .. tip::
 
-   You can enable "x-forwarded-for" and "x-forwarded-proto" profiles for the BIG-IP virtual server(s).
-   Just create the profiles on the BIG-IP, then add them to the Application Manifest before launching the |cfctlr|.
+   You can apply additional BIG-IP configurations to achieve greater feature parity with `Gorouter`_.
+   For example, you can add 'X_FORWARDED_PROTO: HTTP' and  'X_FORWARDED_PROTO: HTTPS' headers using BIG-IP policies and profiles.
 
+   See :ref:`Deploy the BIG-IP Controller for Cloud Foundry <create-application-manifest>` for instructions.
 
 .. Related
    -------
@@ -101,5 +109,7 @@ Define the |cfctlr| `configuration parameters </products/connectors/cf-bigip-ctl
 
 .. _BIG-IP Local Traffic policy: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/local-traffic-policies-getting-started-12-1-0/1.html
 .. _Gorouter: https://docs.cloudfoundry.org/concepts/architecture/router.html
+.. _TCP Router: https://docs.cloudfoundry.org/adminguide/enabling-tcp-routing.html
+.. _Routing API: https://github.com/cloudfoundry-incubator/routing-api
 .. _Routes and Domains documentation: https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html
 


### PR DESCRIPTION
Problem:
Updates to deployment documentation which are error free
Correct examples
Additional content required for TCP routing feature

Solution:
Added TCP routing information, trimmed examples for clarity, and
corrected various sections and expounded where it seemed appropriate.

@<reviewer_id>

#### What issues does this address?
Fixes #256
Fixes #241

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

