### PR TITLE
Fixes #289 -- pre-release docs build issues

### DIFF
--- a/docs/cloudfoundry/cfctlr-app-install.rst
+++ b/docs/cloudfoundry/cfctlr-app-install.rst
@@ -38,7 +38,7 @@ The :code:`bigip` section of the example |cfctlr| manifest below does the follow
       * :code:`oauth`  (REQUIRED)
       * :code:`route_mode`  (OPTIONAL)
 
-   See the |cfctlr| `configuration parameters </products/connectors/cf-bigip-ctlr/v1.0/#configuration-parameters>`_ table for more information.
+   See the |cfctlr| `configuration parameters`_ table for more information.
 
 .. literalinclude:: /_static/config_examples/manifest.yaml
    :linenos:

--- a/docs/cloudfoundry/index.rst
+++ b/docs/cloudfoundry/index.rst
@@ -8,7 +8,7 @@ F5 Cloud Foundry Container Integration
 Overview
 --------
 
-The F5 Container Integration for `Cloud Foundry`_  consists of the `BIG-IP Controller for Cloud Foundry`_.
+The F5 Container Integration for `Cloud Foundry`_  consists of the |cf-long|, or `cf-bigip-ctlr`_.
 The |cf-long| lets you use your F5 BIG-IP device as an Application Delivery Controller (ADC) in Cloud Foundry, serving North-South traffic.
 You can use the |cfctlr| with `Cloud Foundry`_ or `Pivotal Cloud Foundry`_ (PCF).
 

--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -78,9 +78,7 @@ Thank you for participating in the F5 Beta/Early Release program!
 Feature enhancements introduced as part of a beta release have a **"Beta feature"** tag like the example below to the right.
 If you require assistance with a beta version, please contact your F5 Sales Representative.
 
-.. sidebar::
-
-   :fonticon:`fa fa-flask` **Beta feature**
+.. sidebar:: :fonticon:`fa fa-flask` **Beta feature**
 
    Introduced in <product-name> <version>.
 


### PR DESCRIPTION
Fixes #289 

Required for release of docs for:
- k8s-bigip-ctlr v1.3.0
- cf-bigip-ctlr v1.0.0