### PR TITLE
Fix #292: kubernetes.io/ingress-class default behavior description a little confusing

### DIFF
--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -46,8 +46,13 @@ At minimum, you should define the following properties:
 
 .. hint::
 
-   The :code:`kubernetes.io/ingress.class` property defaults to "f5", so you don't need to include it in your Ingress resource annotation.
-   The |kctlr-long| ignores Ingress resources with any other :code:`ingress.class`.
+   In Kubernetes, the default for the :code:`ingress.class`property` is unset. The |kctlr| automatically manages any Ingress resources for which this property is unset. 
+
+   To avoid conflicts with other Ingress controllers, set the :code:`ingress.class` property to "f5", as shown below:
+
+   :code:`kubernetes.io/ingress.class="f5"`
+
+   Specify a different value for Ingress resources that other controllers should manage. The |kctlr| ignores Ingress resources with any :code:`ingress.class` other than "f5".
 
 .. _create k8s ingress:
 


### PR DESCRIPTION
@jputrino 

#### What issues does this address?
Fixes #292

#### What's this change do?

At http://clouddocs.f5.com/containers/v1/kubernetes/kctlr-ingress.html#quick-start
we say: "The kubernetes.io/ingress.class property defaults to f5". It
defaults to not being set. Our behavior is that if it isn't set, we will
manage the ingress. This is also the default behavior of other ingress
controllers (so that your users can get "cluster-default" ingress
behavior without any effort).

So a user might be surprised that they create an Ingress without this
annotation and have two ingress controllers (nginx and k8s-bigip-ctlr,
say), and both controllers try to manage the Ingress.

Describe that by default it is unset and that the controller will manage
those where it is unset, and describe the conditions where it is a good
idea to set it (like you have multiple ingress controllers for your
cluster)


