### PR TITLE
Add link to devcentral to sidebar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,66 @@
+{% extends "f5_sphinx_theme/layout.html" %}
+{%- block extrahead %}
+<!--
+# Copyright 2017 F5 Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<!-- TWBS viewport -->
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- FontAwesome4 -->
+<script src="https://use.fontawesome.com/21fb8a09c3.js"></script>
+<link href="https://use.fontawesome.com/21fb8a09c3.css" media="all" rel="stylesheet">
+<link href="https://cdn.f5.com/favicon.ico" rel="icon">
+<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+<![endif]-->
+{%- endblock %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-sm-3 col-md-3 sidebartoc">
+       <h4><a href="{{ url_root }}">{{ project }} {{ release }}</a></h4>
+        {%- if sidebars != None %}
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        {% endif %}
+      <hr>
+      <h5>View related articles on <a href="https://devcentral.f5.com/articles?tag=Containers" target="_blank">DevCentral <i class="fa fa-external-link-square"></i></a></h5>
+    </div>
+    <div class="col-md-offset-3 col-sm-offset-3 main">
+      <h4>
+        <a href="/">{{ theme_site_name|striptags|e }}</a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }}</a>
+          <span class="right"><a href="{{ pathto('genindex')}}">Index</a></span>
+      </h4>
+      {% block body %}{% endblock %}
+    </div>
+  </div>
+  {% if (next or prev) and theme_next_prev_link%}
+    <div class="row">
+      <div class="col-lg-12">
+        {% if prev %}
+          <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" class="btn btn-primary pull-left">&lt;&lt; Previous</a>
+        {% endif %}
+        {% if next %}
+          <a href="{{ next.link|e }}" title="{{ next.title|striptags|e }}" accesskey="n" class="btn btn-primary pull-right">Next &gt;&gt;</a>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+</div>
+
+{% endblock %}
+


### PR DESCRIPTION
@amudukutore 

#### What issues does this address?
Fixes #316

#### What's this change do?
I added a link to DevCentral (with the filter "containers") to the bottom of the sidebar.

#### Where should the reviewer start?
See screenshot below to see how the link looks in the sidebar.
![2017-12-18_15-34-01](https://user-images.githubusercontent.com/12143793/34131584-742a952c-e409-11e7-903f-9102f1e04a28.png)

#### Any background context?
We agreed offline that it would be nice to make it easier for customers looking at clouddocs to find articles on DC that cover similar topics. I used the search filter "containers" to cast the widest possible net for related content.
