### PR TITLE
Ingress IP specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     branch: v2
     repo: F5Networks/f5-ci-docs
   script:
-  - ./scripts/deploy-docs.sh publish-container-docs-to-prod containers v1
+  - ./scripts/deploy-docs.sh publish-container-docs-to-prod containers v2
 notifications:
   slack:
     secure: JPfhrjoJMHIolWfr+BggymfsuzcMq8hQrI6NgmbH9Op/1LnP7v0pzXabvePBX6jCzEpB6E/pizwrw/7D5r78+GD6gm2eiZ3NNupBSnVBwSQr51pfAH23RB1pafTgjyllrNJLAWia23ihB1oa+yj3ll/clOXke5o8436IJp+KRUk0q8F0HBbke7lLcGii/H2WqGZ9f6bqee0w6wVCjKL86o5EjbF/muBScw6npeGAyuShILsUybgQwJnCHG2Vn4o4L+ZzGga8FljhUJxEIx4v+m0wwTg7mIRrLQbZ0qCXQfc8hU858koa5+nVTt9Cj3fiLNIOtd0K6RujwTqdPTSMBrpbs7Gr1wzaejaKYsWUeJ1DG75MfpbHhTuUgNHNktgEVU6xiS8NL3RwsqfzU6vLbwe2e1EmAOQN6mTKkD+QU3dtJCPHr1tDydN5BSt+uVrd2EiGGuQMIfLGSPBJgCieu0dHgCAKOArKU0zn/gHJhwjxBALq2w0G75JR/wzz7agyQ4awCYZy866hLJPAMKtk+6Bl9qvmKfWBaXQDqrRpZBlhQqOKz2BL/wLPsP3/fVdubn98Ip3ZiTbXmxSRfNCCk4URsx1k9iWk9Qxs+oXIgBfvXuOJxAuwG7OYSbu6HCf18FbaZ2dmkU2hjicEL3BThHjWwf7V4aNdbtanJqkbh6s=

--- a/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
@@ -51,7 +51,12 @@ spec:
             # Tells the k8s-bigip-ctlr to use local DNS to resolve hostnames
             # Can be replaced with custom DNS server IP or left blank
             # (available as of v1.3.0)
-            "--resolve-ingress-names=LOOKUP"
+            "--resolve-ingress-names=LOOKUP",
+            # Tells the k8s-bigip-ctlr to assign this IP address
+            # to any Ingress with the annotation:
+            # 'virtual-server.f5.com/ip="controller-default"'
+            # (available as of v1.4.0)
+            "--default-ingress-ip=1.2.3.4"
             ]
       imagePullSecrets:
         - name: f5-docker-images

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -91,6 +91,8 @@ Kubernetes
                                       ingress.kubernetes.io/ssl-redirect="true"
                                       ingress.kubernetes.io/allow-http="false"
                                       kubernetes.io/ingress.class="f5"
+   // Also valid
+   kubectl annotate ingress myIngress virtual-server.f5.com/ip="controller-default"
 
 
 OpenShift
@@ -106,6 +108,22 @@ OpenShift
                                  ingress.kubernetes.io/ssl-redirect="true"
                                  ingress.kubernetes.io/allow-http="false"
                                  kubernetes.io/ingress.class="f5"
+
+.. tip::
+
+   There are multiple ways to configure the Virtual IP address for Ingress resources:
+     #. Do not specify it at all, and the controller creates only pools.
+     #. Have an external controller (or manually) set the ``virtual-server.f5.com/ip`` annotation with the desired address.
+     #. Use the DNS lookup option (``resolve-ingress-names``) in the `k8s-bigip-ctlr configuration parameters`_.
+
+        - Controller sets the IP address to the resolved host's IP Address
+
+     #. Set the ``default-ingress-ip`` in the `k8s-bigip-ctlr configuration parameters`_.
+
+        - The controller configures Ingresses with the annotation ``virtual-server.f5.com/ip="controller-default"`` with the IP address specified in the ``default-ingress-ip`` parameter.
+        - Note that there is only one of these ``default-ingress-ip`` parameters per controller. If you want multiple IP addresses, then you can
+          run multiple controllers that each monitor different namespaces. This also enables access control if you don't want certain namespaces
+          to be able to attach to certain VIPs.
 
 
 .. _create k8s ingress:


### PR DESCRIPTION
With the addition of the new Default IP for Ingress feature, it's important to document the different
ways in which VIPs can be configured for Ingresses.

Documentation has been added to mention the ways in which the IP  can be set, via annotation,
DNS lookup, or the default ip configuration parameter for the controller.
