### PR TITLE
Make bigip-ctlr service account name consistent

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,7 @@ rst_epilog = """
 .. _Cluster Role Binding: https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding
 .. _Cluster Role: https://kubernetes.io/docs/admin/authorization/rbac/#role-and-clusterrole
 .. _Cluster: https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/
-.. _ConfigMap: https://kubernetes.io/docs/tasks/configure-pod-container/configmap/
+.. _ConfigMap: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
 .. _configuration parameters specific to OpenShift: %(base_url)s/products/connectors/k8s-bigip-ctlr/latest/#openshift-sdn
 .. _Create a Kubernetes Secret containing your Docker login credentials: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 .. _Create a new partition: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-implementations-12-1-0/29.html

--- a/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: k8s-bigip-ctlr
     spec:
-      serviceAccountName: bigip-ctlr-serviceaccount
+      serviceAccountName: bigip-ctlr
       containers:
         - name: k8s-bigip-ctlr
           # replace the version as needed

--- a/docs/kubernetes/config_examples/f5-k8s-sample-rbac.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-sample-rbac.yaml
@@ -46,5 +46,5 @@ roleRef:
   name: bigip-ctlr-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: bigip-ctlr-serviceaccount
+  name: bigip-ctlr
   namespace: kube-system

--- a/docs/marathon/mctlr-authenticate-dcos.rst
+++ b/docs/marathon/mctlr-authenticate-dcos.rst
@@ -10,9 +10,9 @@ DC/OS Open
 
 Apache Mesos `DC/OS Open <https://dcos.io/>`_ uses `DC/OS oauth <https://dcos.io/docs/1.8/administration/id-and-access-mgt/>`_ to secure access. To use the |mctlr| App with a secure cluster, assign it a user account with permission to access the desired cluster.
 
-#. `Create a user account for the App <https://dcos.io/docs/1.8/administration/id-and-access-mgt/managing-authentication>`_
+#. `Create a user account for the App <https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/oss/managing-authentication/>`_
 
-#. `Generate the HTTP API token <https://dcos.io/docs/1.8/administration/id-and-access-mgt/iam-api/>`_ and record it in a safe place.
+#. `Generate the HTTP API token <https://dcos.io/docs/1.8/administration/id-and-access-mgt/oss/iam-api/>`_ and record it in a safe place.
 
 #. Add the token to your |mctlr| App definition using the ``F5_CC_DCOS_AUTH_TOKEN`` configuration parameter.
 
@@ -25,12 +25,12 @@ Apache Mesos `DC/OS Open <https://dcos.io/>`_ uses `DC/OS oauth <https://dcos.io
 DC/OS Enterprise
 ----------------
 
-`DC/OS Enterprise <https://docs.mesosphere.com/>`_ provides access control via `Service Accounts <https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/>`_.
+`DC/OS Enterprise <https://docs.mesosphere.com/>`_ provides access control via `Service Accounts <https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/ent/service-auth/>`_.
 
-- If you use the ``permissive`` or ``strict`` `Security Mode <https://docs.mesosphere.com/1.8/administration/installing/custom/configuration-parameters/#security>`_, you'll need to create a Service Account for the |mctlr|.
+- If you use the ``permissive`` or ``strict`` `Security Mode <https://docs.mesosphere.com/1.8/administration/installing/ent/custom/configuration-parameters/#security>`_, you'll need to create a Service Account for the |mctlr|.
 - If you have disabled the Security Mode, you don't need to create a Service Account for the |mctlr|.
 
-#. `Create a Service Account <https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth>`_ with the permissions shown below.
+#. `Create a Service Account <https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/ent/service-auth/custom-service-auth>`_ with the permissions shown below.
 
    ================================================   =======
    Resource                                           Action


### PR DESCRIPTION
Problem: The service account name for the controller in the RBAC setup was inconsistent across
examples. This caused confusion in someone using our documentation.

Solution: Adjust the config examples to use "bigip-ctlr" as the service account name, which is what we use when initially creating the account.

Also updated some broken links.

Fixes #321 

