### PR TITLE
Fix highlighting for route controller config

### DIFF
--- a/docs/openshift/kctlr-openshift-routes.rst
+++ b/docs/openshift/kctlr-openshift-routes.rst
@@ -55,7 +55,7 @@ If you haven't already done so, add the |kctlr| `Route configuration parameters`
 
 .. literalinclude:: /openshift/config_examples/f5-kctlr-openshift-routes.yaml
    :linenos:
-   :emphasize-lines: 40-45
+   :emphasize-lines: 47-56
 
 
 .. _create os route:


### PR DESCRIPTION
Problem: Line highlighting for route controller config was highlighting the wrong lines.
Solution: Update the highlighting to point at the route-specific config parameters.

Fixes #323 