### PR TITLE
Ingress IP docs -- edits complete

### DIFF
--- a/docs/_static/reuse/k8s-version-added-1_4.rst
+++ b/docs/_static/reuse/k8s-version-added-1_4.rst
@@ -1,0 +1,3 @@
+.. sidebar:: :fonticon:`fa fa-info-circle fa-lg` Version notice:
+
+   Introduced in `k8s-bigip-ctlr v1.4.0`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,7 @@ rst_epilog = """
 .. _k8s-bigip-ctlr v1.1.0: %(base_url)s/products/connectors/k8s-bigip-ctlr/v1.1/
 .. _k8s-bigip-ctlr v1.2.0: %(base_url)s/products/connectors/k8s-bigip-ctlr/v1.2/
 .. _k8s-bigip-ctlr v1.3.0: %(base_url)s/products/connectors/k8s-bigip-ctlr/v1.3/
+.. _k8s-bigip-ctlr v1.4.0: %(base_url)s/products/connectors/k8s-bigip-ctlr/v1.4/
 .. _kube-proxy: https://kubernetes.io/docs/admin/kube-proxy/
 .. _kubectl: https://kubernetes.io/docs/user-guide/kubectl-overview/
 .. _Kubernetes Dashboard: https://kubernetes.io/docs/user-guide/ui/

--- a/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: k8s-bigip-ctlr
           # replace the version as needed
-          image: "f5networks/k8s-bigip-ctlr:1.3.0"
+          image: "f5networks/k8s-bigip-ctlr:1.4.0"
           env:
             - name: BIGIP_USERNAME
               valueFrom:
@@ -31,31 +31,25 @@ spec:
           args: [
             "--bigip-username=$(BIGIP_USERNAME)",
             "--bigip-password=$(BIGIP_PASSWORD)",
-            "--bigip-url=10.190.24.171",
-            "--bigip-partition=kubernetes",
-            # To manage a single namespace, enter it below
-            # (required in v1.0.0), e.g.:
-            #"--namespace=default",
-            # To manage multiple namespaces, enter a separate flag for each
-            # namespace below (as of v1.1.0), e.g.:
-            #"--namespace=myNamespace1",
-            #"--namespace=myNamespace2",
-            # To manage all namespaces, omit the `namespace` entry or comment
-            # it out
-            # (default as of v1.1.0)
-            # Tell the k8s-bigip-ctlr to load SSL profiles from Kubernetes
-            # Secrets; set to "false" if you only want to use preconfigured
-            # BIG-IP SSL profiles
-            # (available as of v1.3.0)
-            "--use-secrets=true",
-            # Tells the k8s-bigip-ctlr to use local DNS to resolve hostnames
-            # Can be replaced with custom DNS server IP or left blank
-            # (available as of v1.3.0)
-            "--resolve-ingress-names=LOOKUP",
-            # Tells the k8s-bigip-ctlr to assign this IP address
-            # to any Ingress with the annotation:
-            # 'virtual-server.f5.com/ip="controller-default"'
-            # (available as of v1.4.0)
+            "--bigip-url=10.11.12.13",
+            "--bigip-partition=k8s",
+            # The Controller watches all namespaces by default.
+            # To manage a single namespace, or multiple namespaces, provide a
+            # single entry for each. For example:
+            # "--namespace=test",
+            # "--namespace=prod"
+            # The Controller can access Secrets by default;
+            # set to "false" if you only want to use SSL profiles that are
+            # already set up on your BIG-IP device, e.g.
+            # "--use-secrets=false",
+            # The Controller can use local DNS to resolve hostnames;
+            # defaults to LOOKUP; can be replaced with custom DNS server IP
+            # or left blank (introduced in v1.3.0)
+            "--resolve-ingress-names=<DNS_SERVER_IP_ADDRESS>",
+            # The Controller can assign an IP address to Ingress resource(s)
+            # with the "controller-default" annotation;
+            # provide the IP address to use as the default below
+            # (introduced in v1.4.0)
             "--default-ingress-ip=1.2.3.4"
             ]
       imagePullSecrets:

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   annotations:
     # Provide an IP address from the external VLAN on your BIG-IP device;
-    # a hostname resolvable by DNS; or use the default IP
+    # use DNS lookup; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
     virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
@@ -4,22 +4,23 @@ metadata:
   name: ing-fanout
   namespace: default
   annotations:
-    # IP address of a BIG-IP pool member
+    # Provide an IP address from the external VLAN on your BIG-IP device;
+    # a hostname resolvable by DNS; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
-    # BIG-IP partition
-    virtual-server.f5.com/partition: "kubernetes"
-    # Load balancing algorithm
+    # Specify the BIG-IP partition where the Controller should create the virtual server.
+    virtual-server.f5.com/partition: "k8s"
+    # Specify the desired load balancing algorithm
     virtual-server.f5.com/balance: "least-connections-node"
 spec:
   rules:
   - host: mysite.example.com
     http:
       paths:
-      - path: /mysite/app1
+      - path: /app1
         backend:
           serviceName: myService1
           servicePort: 80
-      - path: /mysite/app2
+      - path: /app2
         backend:
           serviceName: myService2
           servicePort: 80

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-health-monitor.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-health-monitor.yaml
@@ -4,8 +4,8 @@ metadata:
   name: ing1
   namespace: default
   annotations:
-    virtual-server.f5.com/ip:        "1.2.3.4"
-    virtual-server.f5.com/partition: "kubernetes"
+    virtual-server.f5.com/ip: "controller-default"
+    virtual-server.f5.com/partition: "k8s"
     virtual-server.f5.com/health: |
       [
         {

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml
@@ -4,10 +4,11 @@ metadata:
   name: ingressTLS
   namespace: default
   annotations:
-    # Provide a BIG-IP Self IP address to assign to the virtual server.
+    # Provide an IP address from the external VLAN on your BIG-IP device;
+    # a hostname resolvable by DNS; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
-    virtual-server.f5.com/partition: "kubernetes"
+    virtual-server.f5.com/partition: "k8s"
     # Allow/deny TLS connections
     ingress.kubernetes.io/ssl-redirect: "true"
     # Allow/deny HTTP connections
@@ -17,7 +18,7 @@ spec:
     # Provide the name of the Secret containing the cert and key you want to use.
     - secretName: myTLSSecret
   backend:
-    # The name of a single Kubernetes Service you want to expose to external
+    # Provide the name of a single Kubernetes Service you want to expose to external
     # traffic using TLS
     serviceName: myService
     servicePort: 443

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   annotations:
     # Provide an IP address from the external VLAN on your BIG-IP device;
-    # a hostname resolvable by DNS; or use the default IP
+    # use DNS lookup; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
     virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-tls.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-tls.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   annotations:
     # Provide an IP address from the external VLAN on your BIG-IP device;
-    # a hostname resolvable by DNS; or use the default IP
+    # use DNS lookup; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
     virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-tls.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-tls.yaml
@@ -4,10 +4,11 @@ metadata:
   name: ingressTLS
   namespace: default
   annotations:
-    # Provide a BIG-IP Self IP address to assign to the virtual server.
+    # Provide an IP address from the external VLAN on your BIG-IP device;
+    # a hostname resolvable by DNS; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
-    virtual-server.f5.com/partition: "kubernetes"
+    virtual-server.f5.com/partition: "k8s"
     # Allow/deny TLS connections
     ingress.kubernetes.io/ssl-redirect: "true"
     # Allow/deny HTTP connections
@@ -18,7 +19,7 @@ spec:
     # Follows the format "/partition/profile_name".
     - secretName: /Common/clientssl
   backend:
-    # The name of a single Kubernetes Service you want to expose to external
+    # Provide the name of a single Kubernetes Service you want to expose to external
     # traffic using TLS
     serviceName: myService
     servicePort: 443

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
@@ -5,7 +5,7 @@ metadata:
  namespace: default
  annotations:
   # Provide an IP address from the external VLAN on your BIG-IP device;
-  # a hostname resolvable by DNS; or use the default IP
+  # use DNS lookup; or use the default IP
   virtual-server.f5.com/ip: "1.2.3.4"
   # Specify the BIG-IP partition where the Controller should create the virtual server.
   virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
@@ -4,31 +4,32 @@ metadata:
  name: ing-virtual-hosting
  namespace: default
  annotations:
-  # BIG-IP pool member IP address
+  # Provide an IP address from the external VLAN on your BIG-IP device;
+  # a hostname resolvable by DNS; or use the default IP
   virtual-server.f5.com/ip: "1.2.3.4"
-  # BIG-IP partition
-  virtual-server.f5.com/partition: "kubernetes"
-  # Load balancing algorithm
+  # Specify the BIG-IP partition where the Controller should create the virtual server.
+  virtual-server.f5.com/partition: "k8s"
+  # Specify the desired load balancing algorithm
   virtual-server.f5.com/balance: "least-connections-node"
-  # Specify the port you want to handle requests
+  # Specify the port on which you want to handle requests
   virtual-server.f5.com/http-port: "80"
 spec:
  rules:
  # URL
- - host: mysite.example.com
+ - host: site1.example.com
    http:
      # path to Service from URL
      paths:
-       - path: /myApp1
+       - path: /app1
          backend:
            serviceName: myService1
            servicePort: 80
  # URL
- - host: yoursite.example.com
+ - host: site2.example.com
    http:
      # path to Service from URL
      paths:
-       - path: /myApp2
+       - path: /app2
          backend:
            serviceName: myService2
            servicePort: 80

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
@@ -4,25 +4,26 @@ metadata:
  name: ing-virtual-hosting
  namespace: default
  annotations:
-  # BIG-IP pool member IP address
+  # Provide an IP address from the external VLAN on your BIG-IP device;
+  # a hostname resolvable by DNS; or use the default IP
   virtual-server.f5.com/ip: "1.2.3.4"
-  # BIG-IP partition
-  virtual-server.f5.com/partition: "kubernetes"
-  # Load balancing algorithm
+  # Specify the BIG-IP partition where the Controller should create the virtual server.
+  virtual-server.f5.com/partition: "k8s"
+  # Specify the desired load balancing algorithm
   virtual-server.f5.com/balance: "least-connections-node"
-  # Specify the port you want to handle requests
+  # Specify the port on which you want to handle requests
   virtual-server.f5.com/http-port: "80"
 spec:
  rules:
- # omit host name (URL) to match all hosts
+ # Omit the host name (URL) to match all hosts
  - http:
-     # Provide path to each Service you want to proxy
+     # Provide the path to each Service you want to proxy
      paths:
-     - path: /myApp1
+     - path: /app1
        backend:
          serviceName: myService1
          servicePort: 80
-     - path: /myApp2
+     - path: /app2
        backend:
          serviceName: myService2
          servicePort: 80

--- a/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
@@ -5,7 +5,7 @@ metadata:
  namespace: default
  annotations:
   # Provide an IP address from the external VLAN on your BIG-IP device;
-  # a hostname resolvable by DNS; or use the default IP
+  # use DNS lookup; or use the default IP
   virtual-server.f5.com/ip: "1.2.3.4"
   # Specify the BIG-IP partition where the Controller should create the virtual server.
   virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-single-ingress.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-single-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   annotations:
     # Provide an IP address from the external VLAN on your BIG-IP device;
-    # a hostname resolvable by DNS; or use the default IP
+    # use DNS lookup; or use the default IP
     virtual-server.f5.com/ip: "1.2.3.4"
     # Specify the BIG-IP partition where the Controller should create the virtual server.
     virtual-server.f5.com/partition: "k8s"

--- a/docs/kubernetes/config_examples/f5-k8s-single-ingress.yaml
+++ b/docs/kubernetes/config_examples/f5-k8s-single-ingress.yaml
@@ -1,13 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ingress1
+  name: singleIngress1
   namespace: default
   annotations:
-    # Provide an IP address from the external VLAN on your BIG-IP device
-    virtual-server.f5.com/ip: "10.190.25.70"
-    # Specify the BIG-IP partition containing the virtual server
-    virtual-server.f5.com/partition: "kubernetes"
+    # Provide an IP address from the external VLAN on your BIG-IP device;
+    # a hostname resolvable by DNS; or use the default IP
+    virtual-server.f5.com/ip: "1.2.3.4"
+    # Specify the BIG-IP partition where the Controller should create the virtual server.
+    virtual-server.f5.com/partition: "k8s"
 spec:
   backend:
     # The name of the Service you want to expose to external traffic

--- a/docs/kubernetes/config_examples/f5-resource-pool-only-example.configmap.yaml
+++ b/docs/kubernetes/config_examples/f5-resource-pool-only-example.configmap.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     f5type: virtual-server
 data:
-  # NOTE: k8s-bigip-ctlr v1.0.0 requires schema v0.1.2
-  schema: "f5schemadb://bigip-virtual-server_v0.1.3.json"
+  # schema v0.1.5 required as of k8s-bigip-ctlr v1.4.0
+  schema: "f5schemadb://bigip-virtual-server_v0.1.5.json"
   data: |
     {
       "virtualServer": {
@@ -25,7 +25,7 @@ data:
           "virtualAddress": {
             "port": 80
           },
-          "partition": "kubernetes",
+          "partition": "k8s",
           "balance": "least-connections-node",
           "mode": "http"
         }

--- a/docs/kubernetes/config_examples/f5-resource-vs-example.configmap.yaml
+++ b/docs/kubernetes/config_examples/f5-resource-vs-example.configmap.yaml
@@ -13,8 +13,8 @@ metadata:
     # tells the k8s-bigip-ctlr to watch this ConfigMap
     f5type: virtual-server
 data:
-  # NOTE: schema v0.1.4 is required as of k8s-bigip-ctlr v1.3.0
-  schema: "f5schemadb://bigip-virtual-server_v0.1.4.json"
+  # NOTE: schema v0.1.5 is required as of k8s-bigip-ctlr v1.4.0
+  schema: "f5schemadb://bigip-virtual-server_v0.1.5.json"
   data: |
     {
       "virtualServer": {
@@ -31,9 +31,9 @@ data:
         "frontend": {
           "virtualAddress": {
             "port": 80,
-            "bindAddr": "173.16.2.2"
+            "bindAddr": "1.2.3.4"
           },
-          "partition": "kubernetes",
+          "partition": "k8s",
           "balance": "least-connections-node",
           "mode": "http"
         }
@@ -47,7 +47,7 @@ metadata:
   labels:
     f5type: virtual-server
 data:
-  schema: "f5schemadb://bigip-virtual-server_v0.1.4.json"
+  schema: "f5schemadb://bigip-virtual-server_v0.1.5.json"
   data: |
     {
       "virtualServer": {
@@ -64,9 +64,9 @@ data:
         "frontend": {
           "virtualAddress": {
             "port": 443,
-            "bindAddr": "173.16.2.2"
+            "bindAddr": "1.2.3.4"
           },
-          "partition": "kubernetes",
+          "partition": "k8s",
           "balance": "least-connections-node",
           "mode": "http",
           "sslProfile": {

--- a/docs/kubernetes/config_examples/f5-resource-vs-example.json
+++ b/docs/kubernetes/config_examples/f5-resource-vs-example.json
@@ -16,9 +16,9 @@
         "port": 80,
         // Sets the IP address of the BIG-IP front-end virtual server //
         // omit if you want to create a pool without a virtual server //
-        "bindAddr": "173.16.2.2"
+        "bindAddr": "1.2.3.4"
       },
-      "partition": "kubernetes",
+      "partition": "k8s",
       // Accepts any BIG-IP load balancing mode; defaults to round-robin if
       // mode is not provided //
       "balance": "round-robin",

--- a/docs/kubernetes/config_examples/f5-resource-vs-iApp-example.configmap.yaml
+++ b/docs/kubernetes/config_examples/f5-resource-vs-iApp-example.configmap.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     f5type: virtual-server
 data:
-  # schema v.0.1.4 is required as of k8s-bigip-ctlr v1.3.0
-  schema: "f5schemadb://bigip-virtual-server_v0.1.4.json"
+  # schema v.0.1.5 is required as of k8s-bigip-ctlr v1.4.0
+  schema: "f5schemadb://bigip-virtual-server_v0.1.5.json"
   data: |
     {
       "virtualServer": {
@@ -16,7 +16,7 @@ data:
           "servicePort": 3000
         },
         "frontend": {
-          "partition": "kubernetes",
+          "partition": "k8s",
           "iapp": "/Common/f5.http",
           "iappPoolMemberTable": {
             "name": "pool__members",

--- a/docs/kubernetes/config_examples/f5-resource-vs-iApp-example.json
+++ b/docs/kubernetes/config_examples/f5-resource-vs-iApp-example.json
@@ -5,7 +5,7 @@
       "servicePort": 3000
     },
     "frontend": {
-      "partition": "kubernetes",
+      "partition": "k8s",
       "iapp": "/Common/f5.http",
       "iappPoolMemberTable": {
         "name": "pool__members",

--- a/docs/kubernetes/kctlr-app-install.rst
+++ b/docs/kubernetes/kctlr-app-install.rst
@@ -91,12 +91,12 @@ Set up RBAC Authentication
 Create a Deployment
 -------------------
 
-#. Define the |kctlr| configurations in a Kubernetes `Deployment`_ using valid JSON or YAML.
+Define the |kctlr| configurations in a Kubernetes `Deployment`_ using valid JSON or YAML.
 
-   .. literalinclude:: /kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml
       :linenos:
 
-   :fonticon:`fa fa-download` :download:`f5-k8s-bigip-ctlr_image-secret.yaml </kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml>`
+:fonticon:`fa fa-download` :download:`f5-k8s-bigip-ctlr_image-secret.yaml </kubernetes/config_examples/f5-k8s-bigip-ctlr_image-secret.yaml>`
 
 Upload the resources to the Kubernetes API server
 -------------------------------------------------
@@ -142,4 +142,5 @@ What's Next
 -----------
 
 - Check out the `k8s-bigip-ctlr reference documentation`_.
-- Learn how to :ref:`expose Services to external traffic using an Ingress <kctlr-ingress-config>`.
+- :ref:`Create a BIG-IP Virtual Server for a Service <kctlr-create-vs>`.
+- :ref:`Create a BIG-IP Virtual Server for an Ingress Resource <kctlr-ingress-config>`.

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -80,7 +80,7 @@ If you're using multiple Controllers to monitor separate namespaces, you can def
 DNS lookup
 ~~~~~~~~~~
 
-The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). When you provide the hostname in the :code:`spec` section of the k8s-bigip-ctlr Deployment file, the Controller attempts to resolve that hostname. It then assigns the resolved host's IP address to the Ingress' virtual server.
+The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). The |kctlr| attempts to resolve any hostname provided in the :code:`spec.rules.host` section of the Ingress Resource. It then assigns the resolved host's IP address to the Ingress' virtual server.
 
 Unattached pools
 ~~~~~~~~~~~~~~~~

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -5,30 +5,12 @@
 
 .. _kctlr-ingress-config:
 
-Expose Services to External Traffic using Ingresses
-===================================================
+Use Ingress Resources to Expose Services to External Traffic
+============================================================
 
 .. include:: /_static/reuse/k8s-version-added-1_1.rst
 
-.. change title to "Use BIG-IP as an Edge Load Balancer "??
-
-You can use the |kctlr-long| and OpenShift to expose Services to external traffic on BIG-IP virtual servers. The |kctlr| has a set of `supported Ingress annotations`_ that allow you to define the objects to create on the BIG-IP system.
-
-The |kctlr| supports four (4) types of Kubernetes `Ingress Resource`_:
-
-- :ref:`single service`,
-- :ref:`simple fanout`,
-- :ref:`name-based virtual hosting`, --OR--
-- :ref:`ingress-TLS`.
-
-
-.. attention::
-
-   The |kctlr| creates one (1) BIG-IP virtual server per Ingress resource. If the Ingress resource incorporates multiple Services, the |kctlr| creates a pool for each Service.
-
-   If you set setting :code:`allowHttp` or :code:`sslRedirect` to "True", the Controller creates two (2) virtual servers.
-
-\
+You can use the |kctlr-long| as an Ingress Controller in Kubernetes.
 
 .. table:: Tasks
 
@@ -44,156 +26,164 @@ The |kctlr| supports four (4) types of Kubernetes `Ingress Resource`_:
    =======  ===================================================================
 
 
+Overview
+--------
+
+The |kctlr| uses the Kubernetes `Ingress resource`_ to expose Services to external traffic as follows:
+
+- creates a BIG-IP virtual server for the Ingress Resource,
+- creates a pool on the virtual server for each Service in the Ingress' path.
+
+The |kctlr| supports the following Ingress resource types:
+
+- :ref:`single service`,
+- :ref:`simple fanout`,
+- :ref:`name-based virtual hosting`, and
+- :ref:`ingress-TLS`.
+
+
+The |kctlr| has a set of `supported Ingress annotations`_ that let you define the objects you want to create on the BIG-IP system.
+
+.. attention::
+
+   The |kctlr| creates one BIG-IP virtual server for each Ingress resource. If the Ingress resource incorporates multiple Services, the |kctlr| creates one pool for each Service.
+
+   If you set :code:`allowHttp` or :code:`sslRedirect` to "True", the Controller creates two virtual servers -- one for HTTP and one for HTTPS.
+
+IP address assignment
+`````````````````````
+
+The |kctlr| supports the following options for IP address assignment. See the `k8s-bigip-ctlr configuration parameters`_ table for more information about these settings.
+
+.. _ingress default IP:
+
+Default IP address
+~~~~~~~~~~~~~~~~~~
+
+.. include:: /_static/reuse/k8s-version-added-1_4.rst
+
+You can set a default IP address for Ingress resources. To do so:
+
+#. Add the ``--default-ingress-ip`` config parameter to the :ref:`k8s-bigip-ctlr Deployment <k8s-bigip-ctlr-deployment>`.
+#. Add the annotation ``virtual-server.f5.com/ip="controller-default"`` to your Ingress resource.
+
+The |kctlr| will replace "controller-default" with the IP address provided for the ``default-ingress-ip`` parameter.
+
+.. important::
+
+   You can only define ``--default-ingress-ip`` once for a single |kctlr| instance.
+
+   If you're running multiple Controllers to monitor separate namespaces, you can define a default IP address for each Controller. This type of deployment allows you to isolate the VIPs in each namespace from each other.
+
+DNS lookup
+~~~~~~~~~~
+
+The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). Provide the hostname in the ``virtual-server.f5.com/ip=`` annotation. The Controller will attempt to resolve the hostname and assign the resolved host's IP address to the Ingress' virtual server.
+
+Unattached pools
+~~~~~~~~~~~~~~~~
+
+You can create :ref:`unattached pools <kctlr-pool-only>` for the Services defined in the Ingress resource. To do so, just omit the ``virtual-server.f5.com/ip=`` annotation from your Ingress resource.
+
+You can then :ref:`use an IPAM system <kctlr-ipam>` to assign an IP address and attach a virtual server to the pools, or use another means to manually route traffic to the pools on the BIG-IP system.
+
+Deployments using multiple Ingress Controllers
+``````````````````````````````````````````````
+
+.. note::
+
+   In Kubernetes, the Ingress resource's :code:`ingress.class` property is unset by default. The |kctlr| automatically manages all Ingress resources that don't have an :code:`ingress.class`` defined.
+
+If you're using more than one Ingress Controller to manage your Ingress resources:
+
+- Set the :code:`ingress.class` property to "f5" for all Ingress resources you want the |kctlr| to manage. ::
+
+   kubernetes.io/ingress.class="f5"
+
+- Define the :code:`ingress.class` as appropriate for the Ingress resources managed by other Ingress Controllers. The |kctlr| ignores Ingress resources that have any :code:`ingress.class` other than "f5".
+
+
 .. _ingress self IP:
 
 Initial Setup
 -------------
 
-#. Create a BIG-IP Self IP address.
+Allocate a `Self IP address`_ from the external network on the BIG-IP system. You'll assign this IP address to the Ingress resource's BIG-IP virtual server.
 
-   Allocate a `Self IP address`_ from the external network on the BIG-IP system. This is the IP address you should assign to the Ingress' virtual server.
+.. note::
 
-.. todo:: add instructions for creating Self IP on BIG-IP; reuse? or link to in VE public cloud docs?
+   - If you intend to create :ref:`unattached pools <kctlr-pool-only>` (pools without a virtual server), you will need to set up another way to route traffic to the pools on the BIG-IP system.
+
+   - If you have already assigned a :ref:`default IP address <ingress default IP>` to the Controller, you may skip this step.
 
 
 .. _ingress-quick-start:
 
-Quick Start
------------
+Set Virtual Server Ingress Annotations using kubectl
+----------------------------------------------------
 
-You can add the `supported Ingress annotations`_ to any existing Ingress resource using :command:`kubectl annotate` or :command:`oc annotate`.
-At minimum, define the following properties:
+Add the `supported Ingress annotations`_ to any existing Ingress resource using :command:`kubectl annotate`. The examples below demonstrate correct usage on the command line.
 
-- :code:`virtual-server.f5.com/ip`
-- :code:`virtual-server.f5.com/partition`
-
-.. hint::
-
-   In Kubernetes/OpenShift, the default for the :code:`ingress.class` property is unset. The |kctlr| automatically manages any Ingress resources for which this property is unset.
-
-   To avoid conflicts with other Ingress controllers, set the :code:`ingress.class` property to "f5", as shown below:
-
-   :code:`kubernetes.io/ingress.class="f5"`
-
-   Specify a different value for Ingress resources that other controllers should manage. The |kctlr| ignores Ingress resources with any :code:`ingress.class` other than "f5".
-
-
-Kubernetes
-``````````
-
-.. code-block:: console
+- Assign an IP address to the Ingress: ::
 
    kubectl annotate ingress myIngress virtual-server.f5.com/ip="1.2.3.4"
-   kubectl annotate ingress myIngress virtual-server.f5.com/partition="k8s"
-                                      virtual-server.f5.com/balance="round-robin"
-                                      virtual-server.f5.com/http-port="80"
-                                      virtual-server.f5.com/health='[{"path": "svc1.bar.com/foo", "send": "HTTP GET /health/foo", "interval": 5, "timeout": 10}]'
-                                      ingress.kubernetes.io/ssl-redirect="true"
-                                      ingress.kubernetes.io/allow-http="false"
-                                      kubernetes.io/ingress.class="f5"
-   // Also valid
+
+- Use the default IP address assigned in the :ref:`k8s-bigip-ctlr Deployment <k8s-bigip-ctlr-deployment>`: ::
+
    kubectl annotate ingress myIngress virtual-server.f5.com/ip="controller-default"
 
+- Set the desired port: ::
 
-OpenShift
-`````````
+   kubectl annotate ingress myIngress virtual-server.f5.com/http-port="80"
 
-.. code-block:: console
+- Set the BIG-IP partition: ::
 
-   oc annotate ingress myIngress virtual-server.f5.com/ip="1.2.3.4"
-   oc annotate ingress myIngress virtual-server.f5.com/partition="openshift"
-                                 virtual-server.f5.com/balance="round-robin"
-                                 virtual-server.f5.com/http-port="80"
-                                 virtual-server.f5.com/health='[{"path": "svc1.bar.com/foo", "send": "HTTP GET /health/foo", "interval": 5, "timeout": 10}]'
-                                 ingress.kubernetes.io/ssl-redirect="true"
-                                 ingress.kubernetes.io/allow-http="false"
-                                 kubernetes.io/ingress.class="f5"
+   kubectl annotate ingress myIngress virtual-server.f5.com/partition="k8s"
 
-.. tip::
+- Set the load balancing method: ::
 
-   There are multiple ways to configure the Virtual IP address for Ingress resources:
-     #. Do not specify it at all, and the controller creates only pools.
-     #. Have an external controller (or manually) set the ``virtual-server.f5.com/ip`` annotation with the desired address.
-     #. Use the DNS lookup option (``resolve-ingress-names``) in the `k8s-bigip-ctlr configuration parameters`_.
+   kubectl annotate ingress myIngress virtual-server.f5.com/balance="round-robin"
 
-        - Controller sets the IP address to the resolved host's IP Address
+- Define a BIG-IP health monitor: ::
 
-     #. Set the ``default-ingress-ip`` in the `k8s-bigip-ctlr configuration parameters`_.
+   kubectl annotate ingress myIngress virtual-server.f5.com/health='[{"path": "svc1.example.com/app1", "send": "HTTP GET /health/svc1", "interval": 5, "timeout": 10}]'
 
-        - The controller configures Ingresses with the annotation ``virtual-server.f5.com/ip="controller-default"`` with the IP address specified in the ``default-ingress-ip`` parameter.
-        - Note that there is only one of these ``default-ingress-ip`` parameters per controller. If you want multiple IP addresses, then you can
-          run multiple controllers that each monitor different namespaces. This also enables access control if you don't want certain namespaces
-          to be able to attach to certain VIPs.
+- Redirect HTTP requests to HTTPS: ::
 
+   kubectl annotate ingress myIngress ingress.kubernetes.io/ssl-redirect="true"
+
+- Deny HTTP requests: ::
+
+   kubectl annotate ingress myIngress ingress.kubernetes.io/allow-http="false"
+
+- Assign the F5 Ingress class to avoid conflicts with other Ingress Controllers: ::
+
+   kubectl annotate ingress myIngress kubernetes.io/ingress.class="f5"
 
 .. _create k8s ingress:
 
-Create an Ingress Resource with the F5 virtual-server annotation
+Define Virtual Server Ingress Annotations in an Ingress Resource
 ----------------------------------------------------------------
 
-Define the `supported Ingress annotations`_ in a Kubernetes `Ingress Resource`_ using valid JSON.
+When creating a new Ingress Resource, include the `supported Ingress annotations`_ as needed. The annotations must be valid JSON.
 
+.. _add health monitor to ingress:
 
-.. _single service:
+Add a BIG-IP Health Monitor to the virtual server for an Ingress
+````````````````````````````````````````````````````````````````
 
-Single Service
-``````````````
+Add the :code:`virtual-server.f5.com/health` annotation to your Ingress resource. The example below shows the correct usage.
 
-A :dfn:`Single Service` Ingress creates a BIG-IP virtual server and server pool for a single Kubernetes Service.
-
-.. literalinclude:: /kubernetes/config_examples/f5-k8s-single-ingress.yaml
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-health-monitor.yaml
+   :caption: Health Monitor Example
    :linenos:
-   :emphasize-lines: 6-10
+   :emphasize-lines: 9-22
 
-:fonticon:`fa fa-download` :download:`f5-k8s-single-ingress.yaml </kubernetes/config_examples/f5-k8s-single-ingress.yaml>`
-
-.. _simple fanout:
-
-Simple Fanout
-`````````````
-
-A :dfn:`Simple Fanout` Ingress creates a BIG-IP virtual server and pools for a group of Kubernetes Services (one pool per Service).
-
-.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
-   :linenos:
-   :emphasize-lines: 7-12
-
-:fonticon:`fa fa-download` :download:`f5-k8s-ingress-fanout.yaml </kubernetes/config_examples/f5-k8s-ingress-fanout.yaml>`
-
-.. _name-based virtual hosting:
-
-Name-based virtual hosting
-``````````````````````````
-
-A :dfn:`Name-based virtual hosting` ingress creates the following BIG-IP objects:
-
-- One (1) virtual server with one (1) pool for each Service.
-- Local traffic policies that route requests to specific pools based on host name and path.
-
-.. tip::
-
-   If you don't specify any hosts or paths, the BIG-IP device will proxy traffic for all hosts/paths for the Service specified in the :code:`backend` section of the virtual-server annotation.
-
-\
-
-.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
-   :linenos:
-   :caption: Specific hosts
-   :emphasize-lines: 6-14, 18, 27
-
-:fonticon:`fa fa-download` :download:`f5-k8s-ingress-virtual-hosting.yaml </kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml>`
-
-.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
-   :linenos:
-   :caption: All hosts
-   :emphasize-lines: 6-14, 17
-
-:fonticon:`fa fa-download` :download:`f5-k8s-ingress-virtual-hosting_all.yaml </kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml>`
 
 .. _ingress-TLS:
 
-TLS
-```
+Secure an Ingress using TLS
+```````````````````````````
 
 You can secure an Ingress using :ref:`Secrets <k8s-ingress-secrets>` or :ref:`BIG-IP SSL profiles <k8s-ingress-bigip-ssl>`.
 
@@ -203,8 +193,8 @@ You can secure an Ingress using :ref:`Secrets <k8s-ingress-secrets>` or :ref:`BI
 
 .. note::
 
-   - You can specify one (1) or more SSL profiles in your Ingress resource.
-   - If you specify a :code:`spec.tls` section without providing the TLS Ingress properties,the BIG-IP device uses local traffic policies to redirect HTTP requests to HTTPS.
+   - You can specify one or more SSL profiles in your Ingress resource.
+   - If you specify a :code:`spec.tls` section without providing the TLS Ingress properties, the BIG-IP device uses its local traffic policies to redirect HTTP requests to HTTPS.
 
 \
 
@@ -221,7 +211,6 @@ BIG-IP SSL profiles
 .. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-tls.yaml
    :caption: TLS Example
    :linenos:
-   :emphasize-lines: 11-14, 16-19
 
 :fonticon:`fa fa-download` :download:`f5-k8s-ingress-tls.yaml </kubernetes/config_examples/f5-k8s-ingress-tls.yaml>`
 
@@ -233,45 +222,93 @@ Kubernetes Secrets
 .. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml
       :caption: TLS Example
       :linenos:
-      :emphasize-lines: 16-18
 
 :fonticon:`fa fa-download` :download:`f5-k8s-ingress-tls-secret.yaml </kubernetes/config_examples/f5-k8s-ingress-tls-secret.yaml>`
 
-.. _add health monitor to ingress:
 
-Create a BIG-IP Health Monitor for an Ingress
----------------------------------------------
+See Example Ingress Resources
+`````````````````````````````
 
-#. Add the :code:`virtual-server.f5.com/health` annotation to your Ingress resource.
+.. _single service:
 
-   .. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-health-monitor.yaml
-      :caption: Health Monitor Example
-      :linenos:
-      :emphasize-lines: 9-22
+Single Service
+~~~~~~~~~~~~~~
 
+A :dfn:`Single Service` Ingress creates a BIG-IP virtual server and server pool for a single Kubernetes Service.
+
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-single-ingress.yaml
+   :linenos:
+
+:fonticon:`fa fa-download` :download:`f5-k8s-single-ingress.yaml </kubernetes/config_examples/f5-k8s-single-ingress.yaml>`
+
+.. _simple fanout:
+
+Simple Fanout
+~~~~~~~~~~~~~
+
+A :dfn:`Simple Fanout` Ingress creates a BIG-IP virtual server and pools for a group of Kubernetes Services (one pool per Service).
+
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-fanout.yaml
+   :linenos:
+
+:fonticon:`fa fa-download` :download:`f5-k8s-ingress-fanout.yaml </kubernetes/config_examples/f5-k8s-ingress-fanout.yaml>`
+
+.. _name-based virtual hosting:
+
+Name-based virtual hosting
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A :dfn:`Name-based virtual hosting` ingress creates the following BIG-IP objects:
+
+- One (1) virtual server with one (1) pool for each Service.
+- Local traffic policies that route requests to specific pools based on host name and path.
+
+.. tip::
+
+   If you don't specify any hosts or paths, the BIG-IP device will proxy traffic for all hosts/paths for the Service specified in the :code:`backend` section of the virtual-server annotation.
+
+\
+
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml
+   :linenos:
+   :caption: Specific hosts
+
+:fonticon:`fa fa-download` :download:`f5-k8s-ingress-virtual-hosting.yaml </kubernetes/config_examples/f5-k8s-ingress-virtual-hosting.yaml>`
+
+.. literalinclude:: /kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml
+   :linenos:
+   :caption: All hosts
+
+:fonticon:`fa fa-download` :download:`f5-k8s-ingress-virtual-hosting_all.yaml </kubernetes/config_examples/f5-k8s-ingress-virtual-hosting_all.yaml>`
 
 .. _deploy ingress resource:
 
 Upload the Ingress to the API server
 ------------------------------------
 
-Use :command:`kubectl create` to upload the Ingress Resource to the Kubernetes API server.
+If you have created a new Ingress resource, use the :command:`create` command to upload it to the API server.
 
 .. code-block:: console
 
-   kubectl create ingress -f <filename>.yaml
-   Ingress "myIngress" created
+   kubectl create ingress -f myIngress.yaml
+
+You can apply updates to an existing Ingress resource using the :command:`apply` command.
+
+.. code-block:: console
+
+   kubectl apply -f myIngress.yaml
+
 
 .. _verify-ingress-vs-created:
 
-Verify creation of BIG-IP objects
----------------------------------
+Verify object creation on the BIG-IP system
+-------------------------------------------
 
 You can use TMOS or the BIG-IP configuration utility to verify that the |kctlr| created the requested BIG-IP objects for your Ingress.
 
 To verify using the BIG-IP configuration utility:
 
-#. Log in to the configuration utility at the management IP address (for example: :code:`https://10.190.25.225/tmui/login.jsp?`).
+#. Log in to the configuration utility at the management IP address (for example, :code:`https://10.190.25.225/tmui/login.jsp?`).
 #. Select the correct partition from the :guilabel:`Partition` drop-down menu.
 #. Go to :menuselection:`Local Traffic --> Virtual Servers` to view all virtual servers, pools, and pool members.
 #. Go to :menuselection:`Local Traffic --> Policies` to view any new policies.

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -69,11 +69,13 @@ You can set a default IP address for Ingress resources. To do so:
 
 The |kctlr| will replace "controller-default" with the IP address provided for the ``default-ingress-ip`` parameter.
 
+When you define a default ingress IP address, each Ingress resource configured to use the "controller-default" IP shares the same BIG-IP virtual server. The |kctlr| attaches a separate policy to the virtual server for each Ingress to ensure correct traffic routing for those resources.
+
 .. important::
 
-   You can only define ``--default-ingress-ip`` once for a single |kctlr| instance.
+   You can only define one ``--default-ingress-ip`` per |kctlr| instance.
 
-   If you're running multiple Controllers to monitor separate namespaces, you can define a default IP address for each Controller. This type of deployment allows you to isolate the VIPs in each namespace from each other.
+If you're using multiple Controllers to monitor separate namespaces, you can define a default IP address for each Controller. This type of deployment allows you to isolate the VIPs in each namespace from each other.
 
 DNS lookup
 ~~~~~~~~~~

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -80,7 +80,7 @@ If you're using multiple Controllers to monitor separate namespaces, you can def
 DNS lookup
 ~~~~~~~~~~
 
-The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). Provide the hostname in the ``virtual-server.f5.com/ip=`` annotation. The Controller will attempt to resolve the hostname and assign the resolved host's IP address to the Ingress' virtual server.
+The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). When you provide the hostname in the :code:`spec` section of the k8s-bigip-ctlr Deployment file, the Controller attempts to resolve that hostname. It then assigns the resolved host's IP address to the Ingress' virtual server.
 
 Unattached pools
 ~~~~~~~~~~~~~~~~
@@ -267,7 +267,7 @@ A :dfn:`Name-based virtual hosting` ingress creates the following BIG-IP objects
 
 .. tip::
 
-   If you don't specify any hosts or paths, the BIG-IP device will proxy traffic for all hosts/paths for the Service specified in the :code:`backend` section of the virtual-server annotation.
+   If you don't specify any hosts or paths, the BIG-IP device will proxy traffic for all hosts/paths for the Service specified in the :code:`backend` section of the Ingress Resource.
 
 \
 

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -80,7 +80,7 @@ If you're using multiple Controllers to monitor separate namespaces, you can def
 DNS lookup
 ~~~~~~~~~~
 
-The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). The |kctlr| attempts to resolve any hostname provided in the :code:`spec.rules.host` section of the Ingress Resource. It then assigns the resolved host's IP address to the Ingress' virtual server.
+The |kctlr| uses DNS lookup to resolve hostnames by default (as of v1.3.0). The |kctlr| attempts to resolve the first hostname provided in the :code:`spec.rules.host` section of the Ingress Resource. It then assigns the resolved host's IP address to the Ingress' virtual server.
 
 Unattached pools
 ~~~~~~~~~~~~~~~~

--- a/docs/kubernetes/kctlr-manage-bigip-objects.rst
+++ b/docs/kubernetes/kctlr-manage-bigip-objects.rst
@@ -223,7 +223,7 @@ The |kctlr-long| can create and manage BIG-IP Local Traffic Manager (LTM) pools 
 
 .. important::
 
-   Before creating unattached pools, make sure the BIG-IP system has another wat to route traffic to the Service(s), such as an `iRule`_ or a `local traffic policy`_. After creating an unattached pool for a Service, use the BIG-IP config utility to add the pool members to the iRule or traffic policy. This ensures proper handling of client connections to your back-end applications.
+   Before creating unattached pools, make sure the BIG-IP system has another way to route traffic to the Service(s), such as an `iRule`_ or a `local traffic policy`_. After creating an unattached pool for a Service, use the BIG-IP config utility to add the pool members to the iRule or traffic policy. This ensures proper handling of client connections to your back-end applications.
 
 .. _kctlr-create-unattached-pool:
 


### PR DESCRIPTION
@sjberman 

#### What issues does this address?
Fixes #319 

#### What's this change do?
- Edit Ingress default IP docs; fix up and clarify Ingress examples
- ensure consistency across examples -- partition name, schema version

#### Where should the reviewer start?
View the [staged documentation](https://s3-us-west-2.amazonaws.com/staging-c2ub89n2qjgt1/f5-ci-docs/pr328/kubernetes/kctlr-ingress.html).

#### Any background context?

Linkcheck will fail the build in travis -- contains a link to product docs for v1.4 that don't exist online yet.
  