### PR TITLE
Updating cf controller documentation.

### DIFF
--- a/docs/cloudfoundry/cf-per-route-virtuals.rst
+++ b/docs/cloudfoundry/cf-per-route-virtuals.rst
@@ -55,6 +55,19 @@ You can use as many Service Plans as you need to define the BIG-IP services your
 
    \
 
+   .. warning::
+
+      It's important to use the proper `CIDR format`_ when allocating IP addresses or networks for the :code:`tier2_ip_range` config parameter (for example, :code:`172.0.0.0/24` for IPv4). Failure to use the proper format may result in errors when the |cfctlr| configures BIG-IP objects.
+
+      When allocating networks, the network prefixes must align with CIDR block boundaries. For example:
+
+      - :code:`10.105.175.245/30` causes failures because it doesn't reference an address at the CIDR boundary.
+      - :code:`10.105.175.244/30`, which correctly references an address at the CIDR boundary, succeeds.
+
+      See `Overview of the Standard Virtual Server`_ on AskF5 for more information.
+
+   \
+
    .. tip::
 
       You can also :ref:`cf-routes-apply-policies-profiles` and/or :ref:`cf-route-health-monitors` in the Service Plan.
@@ -100,7 +113,10 @@ Include any of the following BIG-IP objects in the Service Plan to attach them t
 Add BIG-IP Health Monitors
 ``````````````````````````
 
-You can create a new health monitor in the Service Plan, use an existing BIG-IP health monitor, or both:
+You can attach an existing health monitor, create a new one, or both:
+
+- use any health monitor that exists in the :code:`/Common` partition on the BIG-IP system
+- create a new health monitor in the partition the |cfctlr| manages (in this case, "cf")
 
 .. literalinclude:: /cloudfoundry/config_examples/manifest.yaml
    :linenos:

--- a/docs/cloudfoundry/config_examples/manifest.yaml
+++ b/docs/cloudfoundry/config_examples/manifest.yaml
@@ -66,25 +66,39 @@ applications:
 
       # Include the section below to use the cf-bigip-ctlr as a Service Broker
       # THE SETTINGS IN THIS SECTION ARE ROUTE-SPECIFIC
+      # See http://clouddocs.f5.com/containers/latest/cloudfoundry/cf-per-route-virtuals.html for more information
       SERVICE_BROKER_CONFIG: |
-                            plans:
-                              - description: plan for sb test example,
-                                name: sbtest,
-                                virtualServer:
-                                  - policies:
-                                    - /Common/PreventSpoofOfXFF
-                                  - profiles:
-                                    - /Common/x-forwarded-for
-                                  - sslProfiles:
-                                    - /Common/server-ssl
-                                pool:
-                                  balance: ratio-member
-                                  healthMonitors:
-                                    # Use a health monitor that already exists in the cf partition on the BIG-IP device
-                                    - name: /cf/my-healthMonitor
-                                    # Create a new health monitor
-                                    - name: hm-test
-                                      type: http
-                                      interval: 12
-                                      timeout: 5
-                                      send: hello
+                             {
+                               "plans": [
+                                 {
+                                   "description": "plan for sb test example",
+                                   "name": "sbtest",
+                                   "virtualServer": {
+                                     "policies": [
+                                       "/Common/PreventSpoofOfXFF"
+                                     ],
+                                     "profiles": [
+                                       "/Common/x-forwarded-for"
+                                     ],
+                                     "sslProfiles": [
+                                       "/Common/server-ssl"
+                                     ]
+                                   },
+                                   "pool": {
+                                     "balance": "ratio-member",
+                                     "healthMonitors": [
+                                       {
+                                         "name": "/Common/my-healthMonitor"
+                                       },
+                                       {
+                                         "name": "hm-test",
+                                         "type": "http",
+                                         "interval": 5,
+                                         "timeout": 12,
+                                         "send": "hello"
+                                       }
+                                     ]
+                                   }
+                                 }
+                               ]
+                             }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ rst_epilog = """
 .. _cf-bigip-ctlr v1.1.0: %(base_url)s/products/connectors/cf-bigip-ctlr/v1.1/
 .. _cf-bigip-ctlr reference documentation: %(base_url)s/products/connectors/cf-bigip-ctlr/latest/
 .. _cf-bigip-ctlr service broker config parameters: %(base_url)s/products/connectors/cf-bigip-ctlr/latest/#broker-configs
+.. _CIDR format: https://tools.ietf.org/html/rfc4632
 .. _Cloud Foundry CLI: https://docs.cloudfoundry.org/cf-cli/getting-started.html
 .. _Cloud Foundry: https://cloudfoundry.org/why-cloud-foundry/
 .. _Cluster network: https://kubernetes.io/docs/concepts/cluster-administration/networking/
@@ -182,6 +183,7 @@ rst_epilog = """
 .. _OpenShift F5 Router: https://docs.openshift.org/1.4/install_config/router/f5_router.html
 .. _OpenShift route resources: %(base_url)s/products/connectors/k8s-bigip-ctlr/latest/#openshift-route-resources
 .. _Overview of SNAT features: https://support.f5.com/csp/article/K7820
+.. _Overview of the Standard Virtual Server: https://support.f5.com/csp/article/K93017176
 .. _Pivotal Cloud Foundry: https://pivotal.io/platform
 .. _Pod: https://kubernetes.io/docs/concepts/workloads/pods/pod/
 .. _Pods: https://kubernetes.io/docs/concepts/workloads/pods/pod/


### PR DESCRIPTION
Problem:
 Current Cloud Foundry documentation had an incorrect
 SERVICE_BROKER_CONFIG example in its manifest that needed to be
 corrected. Also some of the documentation on the tier2_ip_range
 configuration parameter needed a little bit more background information
 to help users to set it up properly.

Solution:
 Correct the incorrect SERVICE_BROKER_CONFIG example and add links and a
 warning to call out how to properly set the tier2_ip_range parameter.

Fixes: #367

