### PR TITLE
Fixes #373

### DIFF
--- a/docs/kubernetes/kctlr-use-bigip-k8s.rst
+++ b/docs/kubernetes/kctlr-use-bigip-k8s.rst
@@ -178,7 +178,15 @@ Run :command:`kubectl describe` for any Node in the Cluster and make note of the
 Create a Kubernetes Node for the BIG-IP device
 ``````````````````````````````````````````````
 
-#. Create a Kubernetes Node resource.
+.. important::
+   :class: sidebar
+
+   You need to create a "dummy" Node in Kubernetes to make the Kubernetes API server aware of the BIG-IP device. The BIG-IP node's status will always display as "NotReady" because it is not actually a fully-participating Kubernetes Node. This status has no effect on the BIG-IP's ability to communicate in the overlay network.
+
+   Once you've set up the BIG-IP tunnel and added the BIG-IP "dummy" Node, you should be able to send traffic through the BIG-IP system to and from endpoints within your Kubernetes Cluster.
+   See :ref:`networking troubleshoot openshift` for tips to verify network connectivity.
+
+#. Create a "dummy" Kubernetes Node resource.
 
    - Include all of the flannel Annotations. Define the :code:`backend-data` and :code:`public-ip` Annotations with data from the BIG-IP VXLAN:
 
@@ -213,11 +221,6 @@ Create a Kubernetes Node for the BIG-IP device
       k8s-worker-1   Ready     2d        v1.7.5
 
 
-   .. important::
-
-      The BIG-IP node status will always display as "NotReady" because it is not a schedulable Kubernetes Node.
-
-   Once you've added the BIG-IP "dummy" Node, you should be able to successfully send traffic through the BIG-IP system to and from endpoints within your Kubernetes Cluster.
 
 What's Next
 -----------

--- a/docs/kubernetes/kctlr-use-bigip-k8s.rst
+++ b/docs/kubernetes/kctlr-use-bigip-k8s.rst
@@ -207,13 +207,17 @@ Create a Kubernetes Node for the BIG-IP device
 
       kubectl get nodes
       NAME           STATUS    AGE       VERSION
-      bigip          Ready     5m        v1.7.5
+      bigip          NotReady 5m        v1.7.5
       k8s-master-0   Ready     2d        v1.7.5
       k8s-worker-0   Ready     2d        v1.7.5
       k8s-worker-1   Ready     2d        v1.7.5
 
 
-You should now be able to successfully send traffic through the BIG-IP system to and from endpoints within your Kubernetes Cluster.
+   .. important::
+
+      The BIG-IP node status will always display as "NotReady" because it is not a schedulable Kubernetes Node.
+
+   Once you've added the BIG-IP "dummy" Node, you should be able to successfully send traffic through the BIG-IP system to and from endpoints within your Kubernetes Cluster.
 
 What's Next
 -----------


### PR DESCRIPTION
@f5yacobucci 

#### What issues does this address?
Fixes #373
WIP #<issueid>
...

#### What's this change do?
Fixes #373 -- clarifies that the BIG-IP node status will always be NotReady 

#### Where should the reviewer start?
view changes inline

#### Any background context?
I did include this update in the PR for #314, but I wanted to get this critical fix out there now since that PR is still a WIP.
