### PR TITLE
Add references and links for helm charts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,10 +147,13 @@ rst_epilog = """
 .. _F5 Docker registry: https://hub.docker.com/r/f5networks/
 .. _F5 schema: https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/schemas
 .. _F5 virtual server properties: %(base_url)s/products/connectors/k8s-bigip-ctlr/latest/#virtualserver-configmap-properties
+.. _f5-bigip-ctlr chart: https://github.com/F5Networks/charts/tree/master/src/stable/f5-bigip-ctlr
+.. _f5-bigip-ingress chart: https://github.com/F5Networks/charts/tree/master/src/stable/f5-bigip-ingress
 .. _f5-kube-proxy reference documentation: %(base_url)s/products/connectors/f5-kube-proxy/latest/
 .. _f5-kube-proxy: %(base_url)s/products/connectors/f5-kube-proxy/latest/
 .. _flannel: https://github.com/coreos/flannel
 .. _flannel manifest: https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml
+.. _helm: https://helm.sh
 .. _iApp Pool Member table: %(base_url)s/products/connectors/k8s-bigip-ctlr/latest/#iapp-pool-member-table
 .. _Ingress annotations: %(base_url)s/products/connectors/k8s-bigip-ctlr/latest/#ingress-resources
 .. _Ingress controller: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-controllers

--- a/docs/kubernetes/index.rst
+++ b/docs/kubernetes/index.rst
@@ -66,7 +66,8 @@ The |kctlr-long| documentation set assumes that you:
 Installation
 ------------
 
-You can :ref:`launch the k8s-bigip-ctlr application <install-kctlr>` in Kubernetes using a Deployment.
+- You can :ref:`launch the k8s-bigip-ctlr application <install-kctlr>` in Kubernetes using a Deployment.
+- If you use `helm`_ you can use the `f5-bigip-ctlr chart`_.
 
 .. _k8s-upgrade:
 

--- a/docs/kubernetes/kctlr-app-install.rst
+++ b/docs/kubernetes/kctlr-app-install.rst
@@ -9,6 +9,8 @@ Install the BIG-IP Controller: Kubernetes
 The |kctlr-long| installs via a Kubernetes `Deployment`_.
 The Deployment creates a `ReplicaSet`_ that, in turn, launches a `Pod`_ running the |kctlr| app.
 
+If you use `helm`_ you can use the `f5-bigip-ctlr chart`_ to create and manage the resources below.
+
 .. attention::
 
    These instructions are for a standard Kubernetes environment.

--- a/docs/kubernetes/kctlr-ingress.rst
+++ b/docs/kubernetes/kctlr-ingress.rst
@@ -13,6 +13,8 @@ Overview
 
 You can use the |kctlr-long| as an `Ingress Controller`_ in Kubernetes. To do so, add the |kctlr| `Ingress annotations`_ to a Kubernetes Ingress Resource. The annotations define the objects you want to create on the BIG-IP system.
 
+If you use `helm`_ you can use the `f5-bigip-ingress chart`_ to create and manage the resources below. You may also use the `f5-bigip-ctlr chart`_ to create and manage the resources for the |kctlr| itself, though the charts are independent and may be used separately.
+
 .. note::
 
    This document provides set-up instructions for using the |kctlr| as a Kubernetes Ingress Controller. For a functionality overview, see :ref:`k8s-ingress-controller`.

--- a/docs/openshift/index.rst
+++ b/docs/openshift/index.rst
@@ -43,6 +43,12 @@ In OpenShift, you can use the |kctlr| to use a BIG-IP device(s) to:
 
 .. _openshift-origin-node-health:
 
+Installation
+------------
+
+- You can :ref:`launch the k8s-bigip-ctlr application <install-kctlr-openshift>` in OpenShift using a Deployment.
+- If you use `helm`_ you can use the `f5-bigip-ctlr chart`_.
+
 OpenShift Node Health
 ---------------------
 

--- a/docs/openshift/kctlr-openshift-app-install.rst
+++ b/docs/openshift/kctlr-openshift-app-install.rst
@@ -8,7 +8,7 @@ Install the BIG-IP Controller: OpenShift
 
 Use a `Deployment`_ to install the |octlr-long|.
 
-If you use `helm`_ you can use the `f5-bigip-ctlr chart`_ to create the and manage the resources below.
+If you use `helm`_, you can use the `f5-bigip-ctlr chart`_ to create and manage the resources below.
 
 .. attention::
 

--- a/docs/openshift/kctlr-openshift-app-install.rst
+++ b/docs/openshift/kctlr-openshift-app-install.rst
@@ -8,6 +8,8 @@ Install the BIG-IP Controller: OpenShift
 
 Use a `Deployment`_ to install the |octlr-long|.
 
+If you use `helm`_ you can use the `f5-bigip-ctlr chart`_ to create the and manage the resources below.
+
 .. attention::
 
    These instructions are for the `Openshift`_ Kubernetes distribution.


### PR DESCRIPTION
- updated k8s index and install to reference helm chart for controller and link to stable f5networks/charts.
- updates openshift index and install in same manner.
- updated the kctlr-ingress document to reference the ingress chart and to clarify that the ctlr chart and ingress chart are independent.
- added links to conf.py