### PR TITLE
Add IPAM controller link to ConfigMap docs

### DIFF
--- a/docs/kubernetes/kctlr-k8s-ingress-ctlr.rst
+++ b/docs/kubernetes/kctlr-k8s-ingress-ctlr.rst
@@ -122,4 +122,4 @@ What's Next
 - :ref:`kctlr-per-svc-vs` for L4 ingress and L7 ingress on non-standard ports
 
 
-.. _Rewrite: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/annotations.md#rewrite
+.. _Rewrite: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md#rewrite

--- a/docs/kubernetes/kctlr-manage-bigip-objects.rst
+++ b/docs/kubernetes/kctlr-manage-bigip-objects.rst
@@ -161,6 +161,9 @@ When the |kctlr| discovers the annotated resource, it:
 - creates a new BIG-IP virtual server with the designated IP address, and
 - attaches the existing pool to the virtual server.
 
+The `F5 IPAM Controller`_ can write the :code:`virtual-server.f5.com/ip` annotation for you. See the `f5-ipam-ctlr docs`_ 
+for more information.
+
 .. _kctlr-attach-pool-vs:
 
 .. note::


### PR DESCRIPTION
Problem: The F5 IPAM Controller was linked to in the Ingress documentation, but not the ConfigMap documentation.

Solution: Add a link to the F5 IPAM Controller in the ConfigMap documentation. Also fixed a broken link.

Fixes #405 

