### PR TITLE
The instructions fails on other routedomain than 0

### DIFF
--- a/docs/openshift/kctlr-openshift-bigip-ha.rst
+++ b/docs/openshift/kctlr-openshift-bigip-ha.rst
@@ -167,6 +167,20 @@ Create a VXLAN tunnel
 
    create /net tunnels tunnel **openshift_vxlan** key **0** profile **ose-vxlan** local-address **172.16.1.30** secondary-address **172.16.1.29** traffic-group **traffic-group-1**
 
+.. note::
+
+   When using a non-zero Route Domain, add ``remote-address any`` to the command, as shown below.
+
+.. parsed-literal::
+
+   create /net tunnels tunnel openshift_vxlan key 0 profile ose-vxlan local-address 172.16.1.30 secondary-address 172.16.1.28 traffic-group traffic-group-1 **remote-address** **any**
+
+.. rubric:: BIG-IP Node 02
+
+.. parsed-literal::
+
+   create /net tunnels tunnel openshift_vxlan key 0 profile ose-vxlan local-address 172.16.1.30 secondary-address 172.16.1.29 traffic-group traffic-group-1 **remote-address** **any**
+
 .. _openshift vxlan selfIP ha:
 
 Create a self IP in the VXLAN


### PR DESCRIPTION
What issues does this address?

When you are using different Route Domains you need to add the implicit "remote-address any" otherwize tmsh asummes it's from the Route domain 0 and gives an error.

Environment
*  OpenShift with multiple route domains

#### What issues does this address?
Fixes #<issueid>

#### What's this change do?
Updates the OpenShift BIG-IP HA doc with information about route domains.

#### Where should the reviewer start?

#### Any background context?

