### PR TITLE
Update cfctlr-app-install.rst

### DIFF
--- a/docs/cloudfoundry/cfctlr-app-install.rst
+++ b/docs/cloudfoundry/cfctlr-app-install.rst
@@ -173,6 +173,6 @@ What's Next
 
 .. _Enable Docker in Cloud Foundry: https://docs.cloudfoundry.org/adminguide/docker.html#enable
 .. _Create a read-only Admin user in Cloud Foundry: https://docs.cloudfoundry.org/concepts/roles.html
-.. _Add the BIG-IP device to Cloud Foundry: https://docs.pivotal.io/pivotalcf/1-7/opsguide/custom-load-balancer.html
+.. _Add the BIG-IP device to Cloud Foundry: https://docs.pivotal.io/pivotalcf/latest/customizing/f5-lb.html
 .. _Create a BIG-IP local traffic profile: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-profiles-reference-13-1-0/1.html
 .. _Create a BIG-IP local traffic policy: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-local-traffic-policies-getting-started-13-1-0/1.html

--- a/docs/cloudfoundry/index.rst
+++ b/docs/cloudfoundry/index.rst
@@ -115,7 +115,7 @@ When you deploy a new application with a mapped HTTP route in Cloud Foundry, the
 
 .. seealso::
 
-   The Pivotal Cloud Foundry documentation provides instructions for `adding an external load balancer <https://docs.pivotal.io/pivotalcf/1-7/opsguide/custom-load-balancer.html>`_ to your Cloud Foundry deployment.
+   The Pivotal Cloud Foundry documentation provides instructions for `adding an external load balancer <hhttps://docs.pivotal.io/pivotalcf/latest/customizing/custom-load-balancer.html>`_ to your Cloud Foundry deployment.
 
    See Cloud Foundry's `Routes and Domains documentation`_ for more information about how Gorouter creates and maps routes for applications.
 


### PR DESCRIPTION
Fixes #411 - link to Pivotal doc is breaking builds

@amudukutore 

#### What issues does this address?
Fixes #411 

...

#### What's this change do?
Fixes broken link to BIG-IP onboarding instructions in Pivotal CF docs.

#### Where should the reviewer start?

#### Any background context?

