### PR TITLE
Fixes #417 - sphinx substitution showing up in live docs

### DIFF
--- a/docs/marathon/index.rst
+++ b/docs/marathon/index.rst
@@ -162,7 +162,7 @@ The |mctlr| provides compatibilty with existing Marathon `Health Checks`_. For p
 .. _Marathon Application: https://docs.mesosphere.com/1.8/overview/concepts/#marathon-application
 .. _Marathon REST API: https://mesosphere.github.io/marathon/api-console/index.html
 .. _Mesos cluster: https://docs.mesosphere.com/1.8/overview/concepts/#dcos-cluster
-.. _HTTP methods: http://restfulapi.net/http-methods/
+.. _HTTP methods: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 .. _associate labels with Application tasks: https://dcos.io/docs/1.7/usage/tutorials/task-labels/
 .. _port mappings: https://mesosphere.github.io/marathon/docs/ports.html
 .. _Health Checks: https://mesosphere.github.io/marathon/docs/health-checks.html

--- a/docs/openshift/kctlr-openshift-routes.rst
+++ b/docs/openshift/kctlr-openshift-routes.rst
@@ -61,7 +61,7 @@ Attach Routes to Existing BIG-IP Virtual Servers
 If you need to use BIG-IP system functionality that isn't natively supported by the |kctlr|, you can attach a Route to an existing BIG-IP virtual server.
 Take the steps below **before** you deploy the |kctlr|.
 
-**If you want the |kctlr| to create a new virtual server for your Route,** :ref:`skip to the Basic Deployment section <kctlr routes basic>`.
+**If you want the** |kctlr| **to create a new virtual server for your Route,** :ref:`skip to the Basic Deployment section <kctlr routes basic>`.
 
 #. Create a virtual server in a BIG-IP partition that isn't already managed by a |kctlr| instance.
 


### PR DESCRIPTION
#### What issues does this address?
Fixes #417 

#### What's this change do?
Fixes a formatting issue that caused the `|kctlr|` substitution to show up in the live documentation.

Fixes a broken link that caused the build to fail.

#### Where should the reviewer start?

#### Any background context?

