### PR TITLE
added line for BIG-IP Controller for OpenShift

### DIFF
--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -2,6 +2,7 @@
 :product: BIG-IP Controller for Kubernetes
 :product: BIG-IP Controller for Cloud Foundry
 :product: BIG-IP Controller for Marathon
+:product: BIG-IP Controller for OpenShift
 :type: concept
 
 .. _f5-csi_support-matrix:
@@ -20,6 +21,7 @@ Component                   Version
 |cf-long|                   v1.0.x-1.2.x
 |kctlr-long|                v1.0.x-1.6.x
 |mctlr-long|                v1.0.x-v1.3.x
+|octlr-long|                v1.0.x-1.6.x
 ===================         ==============
 
 .. _connector compatibility:


### PR DESCRIPTION
there was field confusion about whether the BIG-IP controller for OpenShift was supported because the beginning of the page did not explicitly mention it.

----------
Open PRs for *pre-release* content into the `pre-release` branch for the product.

Open PRs into `master` for content that can be published immediately.

If you do not have an [issue](https://github.com/F5Networks/f5-ci-docs/issues) to reference below, please open one before proceeding.

----------

@<reviewer_id>

#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

