### PR TITLE
fix for #435

### DIFF
--- a/docs/troubleshooting/kubernetes.rst
+++ b/docs/troubleshooting/kubernetes.rst
@@ -101,11 +101,17 @@ How do I set the log level?
 
 To change the log level for the |kctlr|:
 
-#. Annotate the :ref:`Deployment <k8s-bigip-ctlr-deployment>` for the |kctlr|.
+#. Edit the :ref:`Deployment <k8s-bigip-ctlr-deployment>` yaml and add the following to the args section.
 
    .. code-block:: console
 
-      kubectl annotate k8s-bigip-ctlr.yaml "--log-level=DEBUG" --namespace=kube-system
+      "--log-level=DEBUG"
+
+#. Replace the |kctlr| deployment
+
+   .. code-block:: console
+
+      kubectl replace -f f5-k8s-bigip-ctlr.yaml
 
 #. Verify the Deployment updated successfully.
 

--- a/docs/troubleshooting/openshift.rst
+++ b/docs/troubleshooting/openshift.rst
@@ -86,7 +86,7 @@ How do I set the log level?
 
 To change the log level for the |kctlr|:
 
-#. Edit the Deloyment yaml and add the following to the args section.
+#. Edit the :ref:`Deployment <kctlr-configure-openshift>` yaml and add the following to the args section.
 
    .. code-block:: console
 

--- a/docs/troubleshooting/openshift.rst
+++ b/docs/troubleshooting/openshift.rst
@@ -86,11 +86,18 @@ How do I set the log level?
 
 To change the log level for the |kctlr|:
 
-#. Annotate the :ref:`Deployment <kctlr-configure-openshift>` for the |kctlr|.
+#. Edit the Deloyment yaml and add the following to the args section.
 
    .. code-block:: console
 
-      oc annotate k8s-bigip-ctlr.yaml "--log-level=DEBUG"
+      "--log-level=DEBUG"
+
+#. Replace the |kctlr| deployment
+
+   .. code-block:: console
+
+      oc replace -f f5-k8s-bigip-ctlr.yaml
+
 
 #. Verify the Deployment updated successfully.
 


### PR DESCRIPTION
----------
Open PRs for *pre-release* content into the `pre-release` branch for the product.

Open PRs into `master` for content that can be published immediately.

If you do not have an [issue](https://github.com/F5Networks/f5-ci-docs/issues) to reference below, please open one before proceeding.

----------

@jputrino

#### What issues does this address?
Fixes #435 
WIP #<issueid>
...

#### What's this change do?

Corrects the method to put the controller into debug mode

#### Where should the reviewer start?

#### Any background context?

Per an email exhange between myself and Ryan Talley the controller does not support this annotation so the only way to put it into debug mode is by adding the arg and re-deploying.

