### PR TITLE
Adding OpenShift v3.11x to the release and versioning matrix

### DIFF
--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -83,7 +83,7 @@ The tables below show the versions used in development testing. The F5 Container
    |                          +-----------------------+--------------------------------------------+--------------------------------------------+                          |
    |                          | v1.6.x                | OpenShift Origin                           | v3.7.x, v3.9.x                             |                          |
    |                          +-----------------------+--------------------------------------------+--------------------------------------------+                          |
-   |                          | v1.7.x                | Red Hat OpenShift Container Platform       | v3.7.x                                     |                          |
+   |                          | v1.7.x                | Red Hat OpenShift Container Platform       | v3.7.x, v3.11x                             |                          |
    |                          |                       | OpenShift Origin                           |                                            |                          |
    |                          |                       +--------------------------------------------+                                            |                          |
    |                          |                       | Red Hat OpenShift Container Platform       |                                            |                          |


### PR DESCRIPTION
Adding OpenShift v3.11x to k8s-bigip-ctlr v1.7x section of the release and versioning matrix.