### PR TITLE
Adding OpenShift v3.11x to the release and versioning martrix

### DIFF
--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -83,7 +83,7 @@ The tables below show the versions used in development testing. The F5 Container
    |                          +-----------------------+--------------------------------------------+--------------------------------------------+                          |
    |                          | v1.6.x                | OpenShift Origin                           | v3.7.x, v3.9.x                             |                          |
    |                          +-----------------------+--------------------------------------------+--------------------------------------------+                          |
-   |                          | v1.7.x                | Red Hat OpenShift Container Platform       | v3.7.x                                     |                          |
+   |                          | v1.7.x                | Red Hat OpenShift Container Platform       | v3.7.x, v3.11x                             |                          |
    |                          |                       | OpenShift Origin                           |                                            |                          |
    |                          |                       +--------------------------------------------+                                            |                          |
    |                          |                       | Red Hat OpenShift Container Platform       |                                            |                          |

--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -21,7 +21,7 @@ Component                   Version
 |cf-long|                   v1.0.x-1.2.x
 |kctlr-long|                v1.0.x-1.7.x
 |mctlr-long|                v1.0.x-v1.3.x
-|octlr-long|                v1.0.x-1.6.x
+|octlr-long|                v1.0.x-1.7.x
 ===================         ==============
 
 .. _connector compatibility:


### PR DESCRIPTION
Adding OpenShift v3.11x to the release and versioning martrix.

This commit moves changes from staging (master) to the live site (v2).