### PR TITLE
Update VLAN and VXLAN example names

### DIFF
--- a/docs/troubleshooting/openshift.rst
+++ b/docs/troubleshooting/openshift.rst
@@ -188,7 +188,7 @@ How do I verify connectivity between the BIG-IP VTEP and the OSE Node?
 
      .. code-block:: console
 
-        tcpdump -i <name-of-BIG-IP-VXLAN-tunnel>
+        tcpdump -i <name_of_vlan_used_for_VTEP>
 
      \
 
@@ -205,7 +205,7 @@ How do I verify connectivity between the BIG-IP VTEP and the OSE Node?
 
      .. code-block:: console
 
-        tcpdump -i <name-of-BIG-IP-VXLAN-tunnel>
+        tcpdump -i <name_of_VXLAN_tunnel_on_BIG-IP>
 
      \
 


### PR DESCRIPTION
Update the VLAN and VXLAN names for the examples at lines 191 and 208. The one at 191 was incorrect. It had the example name of the overlay VXLAN Tunnel and it needed to be the underlay VLAN for the VXLAN tunnel. On line 208 I updated the text of the example name to match the example names used later in the doc.

----------
Open PRs for *pre-release* content into the `pre-release` branch for the product.

Open PRs into `master` for content that can be published immediately.

If you do not have an [issue](https://github.com/F5Networks/f5-ci-docs/issues) to reference below, please open one before proceeding.

----------

@<reviewer_id>

#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

